### PR TITLE
Firefox scroll bug in Web Template

### DIFF
--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -10,7 +10,7 @@
 
     function scrollToBottom() {
         var progress = 0.0;
-        var start = document.body.scrollTop;
+        var start = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
         var dist = document.body.scrollHeight - window.innerHeight - start;
         if( dist < 0 ) return;
 


### PR DESCRIPTION
On Firefox, scrollToButtom function reset to the top before scrolling down to button.