### PR TITLE
Remove Extra Scrollbars on Player Pane

### DIFF
--- a/app/renderer/main.css
+++ b/app/renderer/main.css
@@ -580,7 +580,6 @@ img.issue-icon.warning {
   font-family: Verdana, Geneva, sans-serif;
   font-weight: lighter;
   color: #555;
-  overflow: scroll;
 }
 
 #player .innerText {


### PR DESCRIPTION
There were too many nested divs with "overflow: scroll" on the player
pane, resulting in nested scrollbars. As a fix, I've removed this
property from the outermost #player div. I chose the outermost div for
parity's sake with the editor pane, which puts the scrollbars on the
inner content rather than the outer div.

Fixes issue #66.