### PR TITLE
Add Custom Completer

### DIFF
--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -236,9 +236,10 @@ var inkHighlightRules = function() {
             ],
             push: [
                 {
-                    regex: /(\s*=\s*)/,
+                    regex: /(\w+)(\s*=\s*)/,
                     token: [
-                        "list-decl"
+                        "list-decl.name",
+                        "list-decl" // whitespace & equals sign
                     ],
                     next: "#listItem"
                 },

--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -55,7 +55,7 @@ var inkHighlightRules = function() {
                 "choice", // whitespace
                 "choice.bullets", // * or +
                 "choice", // whitespace
-                "choice.label", // (
+                "choice.label", // ( 
                 "choice.label.name", // label_name
                 "choice.label" // )
             ],
@@ -177,7 +177,7 @@ var inkHighlightRules = function() {
         }],
 
         // Used to parse function calls within divert paramters so that
-        // the closing bracket doesn't accidentally cause the rule to end early.
+        // the closing bracket doesn't accidentally cause the rule to end early. 
         // Having it as a separate rule also allows it to be recursive.
         "#functionCallInDivertParameter": [{
             regex: /\w+\s*\(/,
@@ -197,7 +197,7 @@ var inkHighlightRules = function() {
             regex: /^(\s*)((?:-\s*)+)(?!>)(?:(\(\s*)(\w+)(\s*\)))?/,
             token: [
                 "gather", // whitespace
-                "gather.bullets", // - -
+                "gather.bullets", // - - 
                 "gather.label", // (
                 "gather.label.name", // label_name
                 "gather.label" // )
@@ -209,7 +209,7 @@ var inkHighlightRules = function() {
                 "var-decl", // whitespace
                 "var-decl.keyword"
             ],
-
+            
             push: [{
                 regex: /(\s*)(\w+)(\s*)/,
                 token: [
@@ -217,10 +217,10 @@ var inkHighlightRules = function() {
                     "var-decl.name",
                     "var-decl" // whitespace
                 ]
-            },
+            }, 
 
             // The rest of the assignment line
-            {
+            { 
                 regex: /$/,
                 token: "var-decl",
                 next: "pop"
@@ -280,10 +280,10 @@ var inkHighlightRules = function() {
                     "include", // whitespace
                     "include.filepath"
                 ]
-            },
+            }, 
 
             // The rest of the assignment line
-            {
+            { 
                 regex: /$/,
                 token: "include",
                 next: "pop"
@@ -306,8 +306,8 @@ var inkHighlightRules = function() {
                     "external", // whitespace
                     "external.declaration"
                 ]
-            },
-            {
+            }, 
+            { 
                 regex: /$/,
                 token: "external",
                 next: "pop"
@@ -453,7 +453,7 @@ var inkHighlightRules = function() {
             include: "#mixedContent"
         }]
     }
-
+    
     this.normalizeRules();
 };
 

--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -55,7 +55,7 @@ var inkHighlightRules = function() {
                 "choice", // whitespace
                 "choice.bullets", // * or +
                 "choice", // whitespace
-                "choice.label", // ( 
+                "choice.label", // (
                 "choice.label.name", // label_name
                 "choice.label" // )
             ],
@@ -177,7 +177,7 @@ var inkHighlightRules = function() {
         }],
 
         // Used to parse function calls within divert paramters so that
-        // the closing bracket doesn't accidentally cause the rule to end early. 
+        // the closing bracket doesn't accidentally cause the rule to end early.
         // Having it as a separate rule also allows it to be recursive.
         "#functionCallInDivertParameter": [{
             regex: /\w+\s*\(/,
@@ -197,7 +197,7 @@ var inkHighlightRules = function() {
             regex: /^(\s*)((?:-\s*)+)(?!>)(?:(\(\s*)(\w+)(\s*\)))?/,
             token: [
                 "gather", // whitespace
-                "gather.bullets", // - - 
+                "gather.bullets", // - -
                 "gather.label", // (
                 "gather.label.name", // label_name
                 "gather.label" // )
@@ -209,7 +209,7 @@ var inkHighlightRules = function() {
                 "var-decl", // whitespace
                 "var-decl.keyword"
             ],
-            
+
             push: [{
                 regex: /(\s*)(\w+)(\s*)/,
                 token: [
@@ -217,10 +217,10 @@ var inkHighlightRules = function() {
                     "var-decl.name",
                     "var-decl" // whitespace
                 ]
-            }, 
+            },
 
             // The rest of the assignment line
-            { 
+            {
                 regex: /$/,
                 token: "var-decl",
                 next: "pop"
@@ -280,10 +280,10 @@ var inkHighlightRules = function() {
                     "include", // whitespace
                     "include.filepath"
                 ]
-            }, 
+            },
 
             // The rest of the assignment line
-            { 
+            {
                 regex: /$/,
                 token: "include",
                 next: "pop"
@@ -306,8 +306,8 @@ var inkHighlightRules = function() {
                     "external", // whitespace
                     "external.declaration"
                 ]
-            }, 
-            { 
+            },
+            {
                 regex: /$/,
                 token: "external",
                 next: "pop"
@@ -453,7 +453,7 @@ var inkHighlightRules = function() {
             include: "#mixedContent"
         }]
     }
-    
+
     this.normalizeRules();
 };
 

--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -465,6 +465,26 @@ inkHighlightRules.metaData = {
 
 oop.inherits(inkHighlightRules, TextHighlightRules);
 
+// Provide Ink Keywords for Auto-Completer
+const keywords = [
+    "CONST",
+    "CHOICE_COUNT",
+    "DONE",
+    "END",
+    "INCLUDE",
+    "LIST",
+    "LIST_ALL",
+    "LIST_COUNT",
+    "LIST_INVERT",
+    "LIST_MAX",
+    "LIST_MIN",
+    "LIST_RANGE",
+    "LIST_VALUE",
+    "TODO",
+    "TURNS_SINCE",
+    "VAR",
+];
+
 var InkMode = function() {
     this.HighlightRules = inkHighlightRules;
 };
@@ -476,6 +496,14 @@ oop.inherits(InkMode, TextMode);
     this.blockComment = {start: "/*", end: "*/"};
 
     this.$id = "ace/mode/ink"
+
+    this.getCompletions = function(state, session, pos, prefix) {
+        return keywords.map((keyword) => ({
+            caption: keyword,
+            value: keyword,
+            meta: "Ink Keyword",
+        }));
+    }
 }).call(InkMode.prototype);
 
 exports.InkMode = InkMode;

--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -33,7 +33,7 @@ editor.completers = editor.completers.filter(
     (completer) => completer !== language_tools.textCompleter);
 editor.completers.push(inkCompleter);
 
-// Unfortunately standard jquery events don't work since
+// Unfortunately standard jquery events don't work since 
 // Ace turns pointer events off
 editor.on("click", function(e){
 
@@ -89,7 +89,7 @@ editor.on("mousemove", function (e) {
             }
         }
     }
-
+    
     editor.renderer.setCursorStyle("default");
 });
 
@@ -117,7 +117,7 @@ function addError(error) {
     var aceClass = "ace-error";
     var markerId = editor.session.addMarker(
         new Range(error.lineNumber-1, 0, error.lineNumber, 0),
-        editorClass,
+        editorClass, 
         "line",
         false
     );
@@ -157,14 +157,14 @@ exports.EditorView = {
         editor.focus();
     },
     focus: () => { editor.focus(); },
-    saveCursorPos: () => {
-        savedCursorPos = editor.getCursorPosition();
-        savedScrollRow = editor.getFirstVisibleRow();
+    saveCursorPos: () => { 
+        savedCursorPos = editor.getCursorPosition(); 
+        savedScrollRow = editor.getFirstVisibleRow(); 
     },
-    restoreCursorPos: () => {
+    restoreCursorPos: () => { 
         if( savedCursorPos ) {
-            editor.moveCursorToPosition(savedCursorPos);
+            editor.moveCursorToPosition(savedCursorPos); 
             editor.scrollToRow(savedScrollRow);
-        }
+        } 
     }
 };

--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -18,14 +18,12 @@ var events = {
 
 editor.setShowPrintMargin(false);
 editor.setOptions({
-    enableLiveAutocompletion: true
+    enableLiveAutocompletion: false
 });
 editor.on("change", () => {
     events.change();
 });
 
-/* TODO: It's possible to complete custom keywords.
-   Can do this when we have them parsed from the ink file.
 var staticWordCompleter = {
     getCompletions: function(editor, session, pos, prefix, callback) {
         var wordList = ["foo", "bar", "baz"];
@@ -39,8 +37,10 @@ var staticWordCompleter = {
 
     }
 }
-editor.completers = [staticWordCompleter];
-*/
+// This intentionally excludes editor.textCompleter, but it also has the effect
+// of excluding editor.snippetCompleter and editor.keyWordCompleter, which are
+// currently unused by Inky but might be useful in the future.
+editor.setCompleters([staticWordCompleter]);
 
 // Unfortunately standard jquery events don't work since
 // Ace turns pointer events off

--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -42,7 +42,7 @@ var staticWordCompleter = {
 editor.completers = [staticWordCompleter];
 */
 
-// Unfortunately standard jquery events don't work since 
+// Unfortunately standard jquery events don't work since
 // Ace turns pointer events off
 editor.on("click", function(e){
 
@@ -98,7 +98,7 @@ editor.on("mousemove", function (e) {
             }
         }
     }
-    
+
     editor.renderer.setCursorStyle("default");
 });
 
@@ -126,7 +126,7 @@ function addError(error) {
     var aceClass = "ace-error";
     var markerId = editor.session.addMarker(
         new Range(error.lineNumber-1, 0, error.lineNumber, 0),
-        editorClass, 
+        editorClass,
         "line",
         false
     );
@@ -163,14 +163,14 @@ exports.EditorView = {
         editor.focus();
     },
     focus: () => { editor.focus(); },
-    saveCursorPos: () => { 
-        savedCursorPos = editor.getCursorPosition(); 
-        savedScrollRow = editor.getFirstVisibleRow(); 
+    saveCursorPos: () => {
+        savedCursorPos = editor.getCursorPosition();
+        savedScrollRow = editor.getFirstVisibleRow();
     },
-    restoreCursorPos: () => { 
+    restoreCursorPos: () => {
         if( savedCursorPos ) {
-            editor.moveCursorToPosition(savedCursorPos); 
+            editor.moveCursorToPosition(savedCursorPos);
             editor.scrollToRow(savedScrollRow);
-        } 
+        }
     }
 };

--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -149,10 +149,12 @@ exports.EditorView = {
     gotoLine: (row, col) => { editor.gotoLine(row, col); },
     addError: addError,
     setErrors: setErrors,
+    setFiles: (inkFiles) => {
+        inkCompleter.inkFiles = inkFiles;
+    },
     showInkFile: (inkFile) => {
         editor.setSession(inkFile.getAceSession());
         editor.focus();
-        inkCompleter.inkFile = inkFile;
     },
     focus: () => { editor.focus(); },
     saveCursorPos: () => {

--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -3,6 +3,8 @@ const Range = ace.require("ace/range").Range;
 const TokenIterator = ace.require("ace/token_iterator").TokenIterator;
 const language_tools = ace.require("ace/ext/language_tools");
 
+const inkCompleter = require("./inkCompleter.js").inkCompleter;
+
 var editorMarkers = [];
 var editorAnnotations = [];
 
@@ -26,23 +28,10 @@ editor.on("change", () => {
     events.change();
 });
 
-var staticWordCompleter = {
-    getCompletions: function(editor, session, pos, prefix, callback) {
-        var wordList = ["foo", "bar", "baz"];
-        callback(null, wordList.map(function(word) {
-            return {
-                caption: word,
-                value: word,
-                meta: "static"
-            };
-        }));
-
-    }
-}
-// Exclude language_tools.textCompleter but add the static completer
+// Exclude language_tools.textCompleter but add the Ink completer
 editor.completers = editor.completers.filter(
     (completer) => completer !== language_tools.textCompleter);
-editor.completers.push(staticWordCompleter);
+editor.completers.push(inkCompleter);
 
 // Unfortunately standard jquery events don't work since
 // Ace turns pointer events off

--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -152,6 +152,7 @@ exports.EditorView = {
     showInkFile: (inkFile) => {
         editor.setSession(inkFile.getAceSession());
         editor.focus();
+        inkCompleter.inkFile = inkFile;
     },
     focus: () => { editor.focus(); },
     saveCursorPos: () => {

--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -1,6 +1,7 @@
 const editor = ace.edit("editor");
 const Range = ace.require("ace/range").Range;
 const TokenIterator = ace.require("ace/token_iterator").TokenIterator;
+const language_tools = ace.require("ace/ext/language_tools");
 
 var editorMarkers = [];
 var editorAnnotations = [];
@@ -18,7 +19,8 @@ var events = {
 
 editor.setShowPrintMargin(false);
 editor.setOptions({
-    enableLiveAutocompletion: false
+    enableBasicAutocompletion: true,
+    enableLiveAutocompletion: false,
 });
 editor.on("change", () => {
     events.change();
@@ -37,10 +39,10 @@ var staticWordCompleter = {
 
     }
 }
-// This intentionally excludes editor.textCompleter, but it also has the effect
-// of excluding editor.snippetCompleter and editor.keyWordCompleter, which are
-// currently unused by Inky but might be useful in the future.
-editor.setCompleters([staticWordCompleter]);
+// Exclude language_tools.textCompleter but add the static completer
+editor.completers = editor.completers.filter(
+    (completer) => completer !== language_tools.textCompleter);
+editor.completers.push(staticWordCompleter);
 
 // Unfortunately standard jquery events don't work since
 // Ace turns pointer events off

--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -22,7 +22,7 @@ var events = {
 editor.setShowPrintMargin(false);
 editor.setOptions({
     enableBasicAutocompletion: true,
-    enableLiveAutocompletion: false,
+    enableLiveAutocompletion: true,
 });
 editor.on("change", () => {
     events.change();

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -1,0 +1,14 @@
+exports.inkCompleter = {
+    getCompletions: function(editor, session, pos, prefix, callback) {
+        // Ignore pos and prefix. ACE will find the most likely words in the
+        // list for the prefix automatically.
+        var wordList = ["foo", "bar", "baz"];
+        callback(null, wordList.map(function(word) {
+            return {
+                caption: word,
+                value: word,
+                meta: "static"
+            };
+        }));
+    }
+}

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -1,14 +1,18 @@
 exports.inkCompleter = {
-    getCompletions: function(editor, session, pos, prefix, callback) {
-        // Ignore pos and prefix. ACE will find the most likely words in the
-        // list for the prefix automatically.
-        var wordList = ["foo", "bar", "baz"];
-        callback(null, wordList.map(function(word) {
-            return {
+    inkFile: null,
+
+    getCompletions(editor, session, pos, prefix, callback) {
+        if (this.inkFile) {
+            const knots = this.inkFile.symbols.getSymbols();
+            const words = Object.keys(knots);
+
+            // Ignore pos and prefix. ACE will find the most likely words in the
+            // list for the prefix automatically.
+            callback(null, words.map((word) => ({
                 caption: word,
                 value: word,
-                meta: "static"
-            };
-        }));
+                meta: "Knot"
+            })));
+        }
     }
 }

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -1,55 +1,74 @@
+function union(...sets) {
+    const u = new Set();
+    for (const set of sets) {
+        for (const elem of set) {
+            u.add(elem);
+        }
+    }
+    return u;
+}
+
 // Helper function that gets all the divert targets from a list of InkFiles
 function getAllDivertTargets(files) {
     return files.reduce(
-        (acc, cur) => acc.concat(cur.symbols.getDivertTargets()),
+        (acc, cur) => union(acc, cur.symbols.getDivertTargets()),
         []);
 }
 
 // Helper function that gets all the variable names from a list of InkFiles
 function getAllVariables(files) {
     return files.reduce(
-        (acc, cur) => acc.concat(cur.symbols.getVariables()),
+        (acc, cur) => union(acc, cur.symbols.getVariables()),
         []);
 }
 
 // Helper function that gets all the vocabulary words from a list of InkFiles
 function getAllVocabWords(files) {
     return files.reduce(
-        (acc, cur) => acc.concat(cur.symbols.getVocabWords()),
+        (acc, cur) => union(acc, cur.symbols.getVocabWords()),
         []);
 }
 
 // Helper function that generates suggestions for all the divert targets
 function getAllDivertTargetSuggestions(inkFiles) {
     const targets = getAllDivertTargets(inkFiles);
-    return targets.map(
-        target => ({
+    const suggestions = [];
+    for (const target of targets) {
+        suggestions.push({
             caption: target,
             value: target,
             meta: "Divert Target",
-        }));
+        });
+    }
+    return suggestions;
 }
 
 // Helper function that generates suggestions for all the variables
 function getAllVariableSuggestions(inkFiles) {
     const variables = getAllVariables(inkFiles);
-    return variables.map(
-        variableName => ({
-            caption: variableName,
-            value: variableName,
+    const suggestions = [];
+    for (const variable of variables) {
+        suggestions.push({
+            caption: variable,
+            value: variable,
             meta: "Variable",
-        }));
+        });
+    }
+    return suggestions;
 }
 
 // Helper function that generates suggestions for all the vocabulary
 function getAllVocabSuggestions(inkFiles) {
     const vocabWords = getAllVocabWords(inkFiles);
-    return vocabWords.map(
-        word => ({
-            caption: word,
-            value: word,
+    const suggestions = [];
+    for (const vocabWord of vocabWords) {
+        suggestions.push({
+            caption: vocabWord,
+            value: vocabWord,
             meta: "Vocabulary",
-        }));
+        });
+    }
+    return suggestions;
 }
 
 exports.inkCompleter = {

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -10,17 +10,17 @@ function union(sets) {
 
 // Helper function that gets all the divert targets from a list of InkFiles
 function getAllDivertTargets(files) {
-    return union(files.map((file) => file.symbols.getDivertTargets()));
+    return union(files.map((file) => file.symbols.getCachedDivertTargets()));
 }
 
 // Helper function that gets all the variable names from a list of InkFiles
 function getAllVariables(files) {
-    return union(files.map((file) => file.symbols.getVariables()));
+    return union(files.map((file) => file.symbols.getCachedVariables()));
 }
 
 // Helper function that gets all the vocabulary words from a list of InkFiles
 function getAllVocabWords(files) {
-    return union(files.map((file) => file.symbols.getVocabWords()));
+    return union(files.map((file) => file.symbols.getCachedVocabWords()));
 }
 
 // Helper function that generates suggestions for all the divert targets

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -25,6 +25,13 @@ function getAllSymbols(files) {
     return globalSymbolList;
 }
 
+// Helper function that gets all the variable names from a list of InkFiles
+function getAllVariables(files) {
+    return files.reduce(
+        (acc, cur) => acc.concat(cur.symbols.getVariables()),
+        []);
+}
+
 exports.inkCompleter = {
     inkFiles: [],
 
@@ -37,9 +44,17 @@ exports.inkCompleter = {
                 meta: symbol.flowType.name,
             }));
 
+        const variables = getAllVariables(this.inkFiles);
+        const variableSuggestions = variables.map(
+            (variableName) => ({
+                caption: variableName,
+                value: variableName,
+                meta: "Variable",
+            }));
+
         // Ignore pos and prefix. ACE will find the most likely words in the
         // list for the prefix automatically.
 
-        callback(null, symbolSuggestions);
+        callback(null, symbolSuggestions.concat(variableSuggestions));
     }
 };

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -1,4 +1,4 @@
-function union(...sets) {
+function union(sets) {
     const u = new Set();
     for (const set of sets) {
         for (const elem of set) {
@@ -10,23 +10,17 @@ function union(...sets) {
 
 // Helper function that gets all the divert targets from a list of InkFiles
 function getAllDivertTargets(files) {
-    return files.reduce(
-        (acc, cur) => union(acc, cur.symbols.getDivertTargets()),
-        []);
+    return union(files.map((file) => file.symbols.getDivertTargets()));
 }
 
 // Helper function that gets all the variable names from a list of InkFiles
 function getAllVariables(files) {
-    return files.reduce(
-        (acc, cur) => union(acc, cur.symbols.getVariables()),
-        []);
+    return union(files.map((file) => file.symbols.getVariables()));
 }
 
 // Helper function that gets all the vocabulary words from a list of InkFiles
 function getAllVocabWords(files) {
-    return files.reduce(
-        (acc, cur) => union(acc, cur.symbols.getVocabWords()),
-        []);
+    return union(files.map((file) => file.symbols.getVocabWords()));
 }
 
 // Helper function that generates suggestions for all the divert targets

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -2,7 +2,7 @@ exports.inkCompleter = {
     inkFile: null,
 
     getCompletions(editor, session, pos, prefix, callback) {
-        if (this.inkFile) {
+        if ( this.inkFile ) {
             const knots = this.inkFile.symbols.getSymbols();
             const words = Object.keys(knots);
 

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -16,4 +16,4 @@ exports.inkCompleter = {
             meta: "Knot"
         })));
     }
-}
+};

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -1,19 +1,45 @@
+// Helper function that takes a list of InkFiles and walks their symbol trees to
+// get all the symbols in a flat list.
+function getAllSymbols(files) {
+    let globalSymbolList = [];
+
+    // Helper function that walks a symbol tree to find all the symbol names in
+    // it.
+    function walkSymbolTree(tree) {
+        for (const symbolName in tree) {
+            if (tree.hasOwnProperty(symbolName)) {
+                const symbol = tree[symbolName];
+                globalSymbolList.push(symbol);
+                if (symbol.innerSymbols) {
+                    walkSymbolTree(symbol.innerSymbols);
+                }
+            }
+        }
+    }
+
+    files.forEach((inkFile) => {
+        const tree = inkFile.symbols.getSymbols();
+        walkSymbolTree(tree);
+    });
+
+    return globalSymbolList;
+}
+
 exports.inkCompleter = {
     inkFiles: [],
 
     getCompletions(editor, session, pos, prefix, callback) {
-        const wordsPerInclude = this.inkFiles.map((inkFile) => {
-            const knots = inkFile.symbols.getSymbols();
-            return Object.keys(knots);
-        });
-        const words = [].concat.apply([], wordsPerInclude);
+        const symbols = getAllSymbols(this.inkFiles);
+        const symbolSuggestions = symbols.map(
+            (symbol) => ({
+                caption: symbol.name,
+                value: symbol.name,
+                meta: symbol.flowType.name,
+            }));
 
         // Ignore pos and prefix. ACE will find the most likely words in the
         // list for the prefix automatically.
-        callback(null, words.map((word) => ({
-            caption: word,
-            value: word,
-            meta: "Knot"
-        })));
+
+        callback(null, symbolSuggestions);
     }
 };

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -1,18 +1,19 @@
 exports.inkCompleter = {
-    inkFile: null,
+    inkFiles: [],
 
     getCompletions(editor, session, pos, prefix, callback) {
-        if ( this.inkFile ) {
-            const knots = this.inkFile.symbols.getSymbols();
-            const words = Object.keys(knots);
+        const wordsPerInclude = this.inkFiles.map((inkFile) => {
+            const knots = inkFile.symbols.getSymbols();
+            return Object.keys(knots);
+        });
+        const words = [].concat.apply([], wordsPerInclude);
 
-            // Ignore pos and prefix. ACE will find the most likely words in the
-            // list for the prefix automatically.
-            callback(null, words.map((word) => ({
-                caption: word,
-                value: word,
-                meta: "Knot"
-            })));
-        }
+        // Ignore pos and prefix. ACE will find the most likely words in the
+        // list for the prefix automatically.
+        callback(null, words.map((word) => ({
+            caption: word,
+            value: word,
+            meta: "Knot"
+        })));
     }
 }

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -6,18 +6,18 @@ function getAllSymbols(files) {
     // Helper function that walks a symbol tree to find all the symbol names in
     // it.
     function walkSymbolTree(tree) {
-        for (const symbolName in tree) {
-            if (tree.hasOwnProperty(symbolName)) {
+        for(const symbolName in tree) {
+            if( tree.hasOwnProperty(symbolName) ) {
                 const symbol = tree[symbolName];
                 globalSymbolList.push(symbol);
-                if (symbol.innerSymbols) {
+                if( symbol.innerSymbols ) {
                     walkSymbolTree(symbol.innerSymbols);
                 }
             }
         }
     }
 
-    files.forEach((inkFile) => {
+    files.forEach(inkFile => {
         const tree = inkFile.symbols.getSymbols();
         walkSymbolTree(tree);
     });
@@ -38,7 +38,7 @@ exports.inkCompleter = {
     getCompletions(editor, session, pos, prefix, callback) {
         const symbols = getAllSymbols(this.inkFiles);
         const symbolSuggestions = symbols.map(
-            (symbol) => ({
+            symbol => ({
                 caption: symbol.name,
                 value: symbol.name,
                 meta: symbol.flowType.name,
@@ -46,7 +46,7 @@ exports.inkCompleter = {
 
         const variables = getAllVariables(this.inkFiles);
         const variableSuggestions = variables.map(
-            (variableName) => ({
+            variableName => ({
                 caption: variableName,
                 value: variableName,
                 meta: "Variable",

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -58,7 +58,7 @@ exports.inkCompleter = {
     getCompletions(editor, session, pos, prefix, callback) {
         // There are three possible ways we may want to suggest completions:
         //
-        // 1) If we are in a divert or knot name, we should only suggest divert
+        // 1) If we are in a divert or divert target, we should only suggest
         //    target names.
         // 2) If we are in a logic section, we should suggest variables,
         //    targets, (because they can be used as variables) and vocab words.
@@ -67,13 +67,15 @@ exports.inkCompleter = {
 
         const cursorToken = session.getTokenAt(pos.row, pos.column);
         const isCursorInDivert = (cursorToken.type.indexOf("divert") != -1);
+        const isCursorInFlow = (cursorToken.type.indexOf("flow") != -1);
+        const isCursorInLabel = (cursorToken.type.indexOf(".label") != -1);
         const isCursorInLogic = (cursorToken.type.indexOf("logic") != -1);
 
         // Ignore the prefix. ACE will find the most likely words in the list
         // for the prefix automatically.
 
         var suggestions;
-        if( isCursorInDivert ) {
+        if( isCursorInDivert || isCursorInFlow || isCursorInLabel ) {
             suggestions = getAllDivertTargetSuggestions(this.inkFiles);
         } else if( isCursorInLogic ) {
             const divertTargetSuggestions = getAllDivertTargetSuggestions(this.inkFiles);

--- a/app/renderer/inkCompleter.js
+++ b/app/renderer/inkCompleter.js
@@ -32,6 +32,13 @@ function getAllVariables(files) {
         []);
 }
 
+// Helper function that gets all the vocabulary words from a list of InkFiles
+function getAllVocabWords(files) {
+    return files.reduce(
+        (acc, cur) => acc.concat(cur.symbols.getVocabWords()),
+        []);
+}
+
 exports.inkCompleter = {
     inkFiles: [],
 
@@ -52,9 +59,17 @@ exports.inkCompleter = {
                 meta: "Variable",
             }));
 
+        const vocabWords = getAllVocabWords(this.inkFiles);
+        const vocabSuggstions = vocabWords.map(
+            word => ({
+                caption: word,
+                value: word,
+                meta: "Vocabulary",
+            }));
+
         // Ignore pos and prefix. ACE will find the most likely words in the
         // list for the prefix automatically.
 
-        callback(null, symbolSuggestions.concat(variableSuggestions));
+        callback(null, symbolSuggestions.concat(variableSuggestions).concat(vocabSuggstions));
     }
 };

--- a/app/renderer/inkFile.js
+++ b/app/renderer/inkFile.js
@@ -19,7 +19,7 @@ var fileIdCounter = 0;
 
 // anyPath can be relative or absolute
 function InkFile(anyPath, mainInkFile, events) {
-    
+
     this.id = fileIdCounter++;
 
     // Default filename if creating a new file, and passed null to constructor
@@ -34,7 +34,7 @@ function InkFile(anyPath, mainInkFile, events) {
             assert(this.mainInkFile.projectDir, "Main ink needs to be saved before we start loading includes with absolute paths.");
             this.relPath = path.relative(this.mainInkFile.projectDir, anyPath);
         }
-    } 
+    }
 
     // Already relative
     else {
@@ -65,7 +65,7 @@ function InkFile(anyPath, mainInkFile, events) {
     // remove it from the project before the include link has been set up.
     this.brandNewEmpty = false;
 
-    // Flag to detect files that have data that hasn't been saved 
+    // Flag to detect files that have data that hasn't been saved
     // out into the compiler's temporary directory that needs to stay
     // in sync with the (potentially unsaved) editor version.
     this.compilerVersionDirty = true;
@@ -89,11 +89,11 @@ function InkFile(anyPath, mainInkFile, events) {
     this.hasUnsavedChanges = false;
     this.aceDocument.on("change", () => {
         this.hasUnsavedChanges = true;
-        this.brandNewEmpty = false;        
+        this.brandNewEmpty = false;
         this.compilerVersionDirty = true;
         this.justSaved = false;
-        
-        if( !this.justLoadedContent ) 
+
+        if( !this.justLoadedContent )
             this.events.fileChanged();
     });
 }
@@ -117,7 +117,7 @@ InkFile.prototype.absolutePath = function() {
     // Unsaved - can't get absolute path?
     if( !mainInk.projectDir )
         return null;
-    
+
     // Normal case: combine the project directory with the file's relative path.
     return path.join(mainInk.projectDir, this.relPath);
 }
@@ -171,10 +171,10 @@ InkFile.prototype.save = function(afterSaveCallback) {
         this.justSaved = true;
         var fileContent = this.aceDocument.getValue();
         if( !fileContent || fileContent.length < 1 ) throw "Empty file content in aceDocument!";
-        
+
         fs.writeFile(this.absolutePath(), fileContent, "utf8", (err) => {
             this.brandNewEmpty = false;
-            if( err ) 
+            if( err )
                 afterSaveCallback(false);
             else {
                 this.hasUnsavedChanges = false;
@@ -209,7 +209,7 @@ InkFile.prototype.tryLoadFromDisk = function(loadCallback) {
     }
 
     fs.stat(absPath, (err, stats) => {
-        if( err || !stats.isFile() ) { 
+        if( err || !stats.isFile() ) {
             loadCallback(false);
             return;
         }
@@ -221,7 +221,7 @@ InkFile.prototype.tryLoadFromDisk = function(loadCallback) {
                 return;
             }
 
-            // Success - fire this callback before other callbacks 
+            // Success - fire this callback before other callbacks
             // like document change get fired
             loadCallback(true);
 

--- a/app/renderer/inkFile.js
+++ b/app/renderer/inkFile.js
@@ -19,7 +19,7 @@ var fileIdCounter = 0;
 
 // anyPath can be relative or absolute
 function InkFile(anyPath, mainInkFile, events) {
-
+    
     this.id = fileIdCounter++;
 
     // Default filename if creating a new file, and passed null to constructor
@@ -34,7 +34,7 @@ function InkFile(anyPath, mainInkFile, events) {
             assert(this.mainInkFile.projectDir, "Main ink needs to be saved before we start loading includes with absolute paths.");
             this.relPath = path.relative(this.mainInkFile.projectDir, anyPath);
         }
-    }
+    } 
 
     // Already relative
     else {
@@ -65,7 +65,7 @@ function InkFile(anyPath, mainInkFile, events) {
     // remove it from the project before the include link has been set up.
     this.brandNewEmpty = false;
 
-    // Flag to detect files that have data that hasn't been saved
+    // Flag to detect files that have data that hasn't been saved 
     // out into the compiler's temporary directory that needs to stay
     // in sync with the (potentially unsaved) editor version.
     this.compilerVersionDirty = true;
@@ -89,11 +89,11 @@ function InkFile(anyPath, mainInkFile, events) {
     this.hasUnsavedChanges = false;
     this.aceDocument.on("change", () => {
         this.hasUnsavedChanges = true;
-        this.brandNewEmpty = false;
+        this.brandNewEmpty = false;        
         this.compilerVersionDirty = true;
         this.justSaved = false;
-
-        if( !this.justLoadedContent )
+        
+        if( !this.justLoadedContent ) 
             this.events.fileChanged();
     });
 }
@@ -117,7 +117,7 @@ InkFile.prototype.absolutePath = function() {
     // Unsaved - can't get absolute path?
     if( !mainInk.projectDir )
         return null;
-
+    
     // Normal case: combine the project directory with the file's relative path.
     return path.join(mainInk.projectDir, this.relPath);
 }
@@ -171,10 +171,10 @@ InkFile.prototype.save = function(afterSaveCallback) {
         this.justSaved = true;
         var fileContent = this.aceDocument.getValue();
         if( !fileContent || fileContent.length < 1 ) throw "Empty file content in aceDocument!";
-
+        
         fs.writeFile(this.absolutePath(), fileContent, "utf8", (err) => {
             this.brandNewEmpty = false;
-            if( err )
+            if( err ) 
                 afterSaveCallback(false);
             else {
                 this.hasUnsavedChanges = false;
@@ -209,7 +209,7 @@ InkFile.prototype.tryLoadFromDisk = function(loadCallback) {
     }
 
     fs.stat(absPath, (err, stats) => {
-        if( err || !stats.isFile() ) {
+        if( err || !stats.isFile() ) { 
             loadCallback(false);
             return;
         }
@@ -221,7 +221,7 @@ InkFile.prototype.tryLoadFromDisk = function(loadCallback) {
                 return;
             }
 
-            // Success - fire this callback before other callbacks
+            // Success - fire this callback before other callbacks 
             // like document change get fired
             loadCallback(true);
 

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -56,6 +56,7 @@ InkFileSymbols.prototype.parse = function() {
 
     var globalTags = [];
     var globalDictionaryStyleTags = {};
+    var divertTargets = [];
     var variables = [];
     var vocabWords = [];
 
@@ -108,6 +109,7 @@ InkFileSymbols.prototype.parse = function() {
                 });
 
                 symbolStack.push(symbol);
+                divertTargets.push(symbolName);
             }
             else if( varType ) {
                 variables.push(symbolName);
@@ -164,6 +166,7 @@ InkFileSymbols.prototype.parse = function() {
 
     this.globalTags = globalTags;
     this.globalDictionaryStyleTags = globalDictionaryStyleTags;
+    this.divertTargets = divertTargets;
     this.variables = variables;
     this.vocabWords = vocabWords;
 
@@ -221,6 +224,11 @@ InkFileSymbols.prototype.symbolAtPos = function(pos) {
 InkFileSymbols.prototype.getSymbols = function() {
     if( this.dirty ) this.parse();
     return this.symbols;
+}
+
+InkFileSymbols.prototype.getDivertTargets = function() {
+    if( this.dirty ) this.parse();
+    return this.divertTargets;
 }
 
 InkFileSymbols.prototype.getVariables = function() {

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -39,8 +39,8 @@ InkFileSymbols.prototype.parse = function() {
         { name: "Gather", code: "gather.label",        level: 3 },
     ];
     const varTypes = [
-        { name: "Variable", code: "var-decl"},
-        { name: "List", code: "list-decl"},
+        { name: "Variable", code: "var-decl"  },
+        { name: "List",     code: "list-decl" },
     ];
     const topLevelInkFlow = { level: 0 };
 

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -117,6 +117,11 @@ InkFileSymbols.prototype.parse = function() {
             // Not a knot/stitch/gather/choice nor a variable. Do nothing.
         }
 
+        // DIVERT
+        else if( tok.type == "divert.target" && tok.value.trim().length > 0 ) {
+            divertTargets.push(tok.value);
+        }
+
         // LIST
         else if( tok.type == "list-decl.item" && tok.value.trim().length > 0 ) {
             // Extract the name from the line

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -135,10 +135,10 @@ InkFileSymbols.prototype.parse = function() {
         }
 
         // Prose text
-        else if ( tok.type == "text") {
+        else if( tok.type == "text" ) {
             var words = tok.value.split(/\W+/);
             words.forEach(word => {
-                if (word.length >= 3 && !_.includes(vocabWords, word)) {
+                if( word.length >= 3 && !_.includes(vocabWords, word) ) {
                     vocabWords.push(word);
                 }
             });

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -16,7 +16,7 @@ function InkFileSymbols(inkFile, events) {
 }
 
 InkFileSymbols.prototype.scheduleParse = function() {
-    if( this.parseTimeout ) 
+    if( this.parseTimeout )
         clearTimeout(this.parseTimeout);
 
     this.parseTimeout = setTimeout(() => {
@@ -59,7 +59,7 @@ InkFileSymbols.prototype.parse = function() {
     // I don't understand why sometimes the TokenIterator gives something valid
     // initially, and sometimes it doesn't?
     if( it.getCurrentToken() === undefined ) it.stepForward();
-    
+
     for(var tok = it.getCurrentToken(); tok; tok = it.stepForward()) {
 
         // Token is some kind of name?
@@ -79,7 +79,7 @@ InkFileSymbols.prototype.parse = function() {
             // Not a knot/stitch/gather/choice (e.g. might be a variable name)
             if( !flowType )
                 continue;
-            
+
             while( flowType.level <= symbolStack.currentElement().flowType.level )
                 symbolStack.pop();
 
@@ -90,7 +90,7 @@ InkFileSymbols.prototype.parse = function() {
                 column: it.getCurrentTokenColumn(),
                 inkFile: this.inkFile
             };
-            
+
             var parent = symbolStack.currentElement();
             if( parent != symbolStack )
                 symbol.parent = parent;
@@ -161,7 +161,7 @@ InkFileSymbols.prototype.symbolAtPos = function(pos) {
     if( this.dirty ) this.parse();
 
     // Range index is an index of all the symbols by row number,
-    // nested into a hierarchy. 
+    // nested into a hierarchy.
     function symbolWithinIndex(rangeIndex) {
 
         if( !rangeIndex )

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -40,6 +40,7 @@ InkFileSymbols.prototype.parse = function() {
     ];
     const varTypes = [
         { name: "Variable", code: "var-decl"},
+        { name: "List", code: "list-decl"},
     ];
     const topLevelInkFlow = { level: 0 };
 
@@ -112,6 +113,18 @@ InkFileSymbols.prototype.parse = function() {
                 variables.push(symbolName);
             }
             // Not a knot/stitch/gather/choice nor a variable. Do nothing.
+        }
+
+        // LIST
+        else if( tok.type == "list-decl.item" && tok.value.trim().length > 0 ) {
+            // Extract the name from the line
+            var potentialNames = tok.value.match(/\b\w+\b/g);
+            potentialNames.forEach(potentialName => {
+                // Exclude "names" that are only numbers
+                if( !(/^\d*$/.test(potentialName)) ) {
+                    variables.push(potentialName);
+                }
+            });
         }
 
         // INCLUDE

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -56,9 +56,9 @@ InkFileSymbols.prototype.parse = function() {
 
     var globalTags = [];
     var globalDictionaryStyleTags = {};
-    var divertTargets = [];
-    var variables = [];
-    var vocabWords = [];
+    var divertTargets = new Set();
+    var variables = new Set();
+    var vocabWords = new Set();
 
     var it = new TokenIterator(session, 0, 0);
 
@@ -109,17 +109,17 @@ InkFileSymbols.prototype.parse = function() {
                 });
 
                 symbolStack.push(symbol);
-                divertTargets.push(symbolName);
+                divertTargets.add(symbolName);
             }
             else if( varType ) {
-                variables.push(symbolName);
+                variables.add(symbolName);
             }
             // Not a knot/stitch/gather/choice nor a variable. Do nothing.
         }
 
         // DIVERT
         else if( tok.type == "divert.target" && tok.value.trim().length > 0 ) {
-            divertTargets.push(tok.value);
+            divertTargets.add(tok.value);
         }
 
         // LIST
@@ -129,7 +129,7 @@ InkFileSymbols.prototype.parse = function() {
             potentialNames.forEach(potentialName => {
                 // Exclude "names" that are only numbers
                 if( !(/^\d*$/.test(potentialName)) ) {
-                    variables.push(potentialName);
+                    variables.add(potentialName);
                 }
             });
         }
@@ -158,8 +158,8 @@ InkFileSymbols.prototype.parse = function() {
         else if( tok.type == "text" ) {
             var words = tok.value.split(/\W+/);
             words.forEach(word => {
-                if( word.length >= 3 && !_.includes(vocabWords, word) ) {
-                    vocabWords.push(word);
+                if( word.length >= 3 ) {
+                    vocabWords.add(word);
                 }
             });
         }

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -56,6 +56,7 @@ InkFileSymbols.prototype.parse = function() {
     var globalTags = [];
     var globalDictionaryStyleTags = {};
     var variables = [];
+    var vocabWords = [];
 
     var it = new TokenIterator(session, 0, 0);
 
@@ -133,6 +134,16 @@ InkFileSymbols.prototype.parse = function() {
             }
         }
 
+        // Prose text
+        else if ( tok.type == "text") {
+            var words = tok.value.split(/\W+/);
+            words.forEach(word => {
+                if (word.length >= 3 && !_.includes(vocabWords, word)) {
+                    vocabWords.push(word);
+                }
+            });
+        }
+
     } // for token iterator
 
     this.symbols = symbolStack[0].innerSymbols;
@@ -141,6 +152,7 @@ InkFileSymbols.prototype.parse = function() {
     this.globalTags = globalTags;
     this.globalDictionaryStyleTags = globalDictionaryStyleTags;
     this.variables = variables;
+    this.vocabWords = vocabWords;
 
     // Detect whether the includes actually changed at all
     var oldIncludes = this.includes || [];
@@ -211,6 +223,11 @@ InkFileSymbols.prototype.getIncludes = function() {
 InkFileSymbols.prototype.getLastIncludeRow = function() {
     if( this.dirty ) this.parse();
     return this.lastIncludeRow;
+}
+
+InkFileSymbols.prototype.getVocabWords = function() {
+    if( this.dirty ) this.parse();
+    return this.vocabWords;
 }
 
 exports.InkFileSymbols = InkFileSymbols;

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -106,7 +106,8 @@ InkFileSymbols.prototype.parse = function() {
                 });
 
                 symbolStack.push(symbol);
-            } else if ( varType ) {
+            }
+            else if( varType ) {
                 variables.push(symbolName);
             }
             // Not a knot/stitch/gather/choice nor a variable. Do nothing.

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -9,6 +9,10 @@ function InkFileSymbols(inkFile, events) {
     this.dirty = true;
     this.parseTimeout = null;
 
+    this.divertTargets = new Set();
+    this.variables = new Set();
+    this.vocabWords = new Set();
+
     this.inkFile.aceDocument.on("change", () => {
         this.dirty = true;
         this.scheduleParse();
@@ -56,6 +60,7 @@ InkFileSymbols.prototype.parse = function() {
 
     var globalTags = [];
     var globalDictionaryStyleTags = {};
+
     var divertTargets = new Set();
     var variables = new Set();
     var vocabWords = new Set();
@@ -171,6 +176,7 @@ InkFileSymbols.prototype.parse = function() {
 
     this.globalTags = globalTags;
     this.globalDictionaryStyleTags = globalDictionaryStyleTags;
+
     this.divertTargets = divertTargets;
     this.variables = variables;
     this.vocabWords = vocabWords;
@@ -231,16 +237,6 @@ InkFileSymbols.prototype.getSymbols = function() {
     return this.symbols;
 }
 
-InkFileSymbols.prototype.getDivertTargets = function() {
-    if( this.dirty ) this.parse();
-    return this.divertTargets;
-}
-
-InkFileSymbols.prototype.getVariables = function() {
-    if( this.dirty ) this.parse();
-    return this.variables;
-}
-
 InkFileSymbols.prototype.getIncludes = function() {
     if( this.dirty ) this.parse();
     return this.includes;
@@ -251,8 +247,15 @@ InkFileSymbols.prototype.getLastIncludeRow = function() {
     return this.lastIncludeRow;
 }
 
-InkFileSymbols.prototype.getVocabWords = function() {
-    if( this.dirty ) this.parse();
+InkFileSymbols.prototype.getCachedDivertTargets = function() {
+    return this.divertTargets;
+}
+
+InkFileSymbols.prototype.getCachedVariables = function() {
+    return this.variables;
+}
+
+InkFileSymbols.prototype.getCachedVocabWords = function() {
     return this.vocabWords;
 }
 

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -16,7 +16,7 @@ function InkFileSymbols(inkFile, events) {
 }
 
 InkFileSymbols.prototype.scheduleParse = function() {
-    if( this.parseTimeout )
+    if( this.parseTimeout ) 
         clearTimeout(this.parseTimeout);
 
     this.parseTimeout = setTimeout(() => {
@@ -63,7 +63,7 @@ InkFileSymbols.prototype.parse = function() {
     // I don't understand why sometimes the TokenIterator gives something valid
     // initially, and sometimes it doesn't?
     if( it.getCurrentToken() === undefined ) it.stepForward();
-
+    
     for(var tok = it.getCurrentToken(); tok; tok = it.stepForward()) {
 
         // Token is some kind of name?
@@ -166,7 +166,7 @@ InkFileSymbols.prototype.symbolAtPos = function(pos) {
     if( this.dirty ) this.parse();
 
     // Range index is an index of all the symbols by row number,
-    // nested into a hierarchy.
+    // nested into a hierarchy. 
     function symbolWithinIndex(rangeIndex) {
 
         if( !rangeIndex )

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -30,6 +30,7 @@ function InkProject(mainInkFilePath) {
     this.mainInk = null;
     this.mainInk = this.createInkFile(mainInkFilePath || null);
 
+    EditorView.setFiles(this.files);
     this.showInkFile(this.mainInk);
 
     this.startFileWatching();
@@ -69,6 +70,7 @@ InkProject.prototype.addNewInclude = function(newIncludePath, addToMainInk) {
         this.mainInk.addIncludeLine(newIncludeFile.relativePath());
 
     NavView.setFiles(this.mainInk, this.files);
+    EditorView.setFiles(this.files);
     return newIncludeFile;
 }
 
@@ -115,6 +117,7 @@ InkProject.prototype.refreshIncludes = function() {
     includeRelPathsToLoad.forEach(newIncludeRelPath => this.createInkFile(newIncludeRelPath));
 
     NavView.setFiles(this.mainInk, this.files);
+    EditorView.setFiles(this.files);
 }
 
 InkProject.prototype.refreshUnsavedChanges = function() {

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -477,6 +477,7 @@ InkProject.prototype.deleteInkFile = function(inkFile) {
     this.files.remove(inkFile);
 
     NavView.setFiles(this.mainInk, this.files);
+    EditorView.setFiles(this.files);
 }
 
 InkProject.prototype.findSymbol = function(name, posContext) {

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -38,7 +38,7 @@ function InkProject(mainInkFilePath) {
 
 InkProject.prototype.createInkFile = function(anyPath) {
     var inkFile = new InkFile(anyPath || null, this.mainInk, {
-        fileChanged: () => {
+        fileChanged: () => { 
             if( inkFile.hasUnsavedChanges && !this.unsavedFiles.contains(inkFile) ) {
                 this.unsavedFiles.push(inkFile);
                 this.refreshUnsavedChanges();
@@ -50,7 +50,7 @@ InkProject.prototype.createInkFile = function(anyPath) {
         },
 
         // Called when InkFile finds an INCUDE line in the contents of the file
-        includesChanged: () => {
+        includesChanged: () => {         
             this.refreshIncludes();
             if( inkFile.includes.length > 0  )
                 NavView.initialShow();
@@ -246,7 +246,7 @@ function copyFile(source, destination, transform) {
         if( !err && fileContent ) {
             if( transform ) fileContent = transform(fileContent);
             if( fileContent.length < 1 ) throw "Trying to write (copy) empty file!";
-
+            
             fs.writeFile(destination, fileContent, "utf8");
         }
     });
@@ -300,7 +300,7 @@ InkProject.prototype.export = function(exportType) {
         }
 
         dialog.showSaveDialog(remote.getCurrentWindow(), saveOptions, (targetSavePath) => {
-            if( targetSavePath ) {
+            if( targetSavePath ) { 
                 this.defaultExportPath = targetSavePath;
 
                 // JSON export - simply move compiled json into place
@@ -320,10 +320,10 @@ InkProject.prototype.export = function(exportType) {
                             }
                         }
 
-                        // JS file:
+                        // JS file: 
                         if( exportType == "js" ) {
                             this.convertJSONToJS(compiledJsonTempPath, targetSavePath);
-                        }
+                        } 
 
                         // JSON: Just copy into place
                         else {
@@ -384,7 +384,7 @@ InkProject.prototype.buildForWeb = function(jsonFilePath, targetDirectory) {
 
     // Derive story title from save name
     var storyTitle = path.basename(targetDirectory);
-
+    
     // Unless the writer explicitly provided a tag with the title
     var mainInkTagDict = this.mainInk.symbols.globalDictionaryStyleTags;
     if( mainInkTagDict && mainInkTagDict["title"] ) {
@@ -401,8 +401,8 @@ InkProject.prototype.buildForWeb = function(jsonFilePath, targetDirectory) {
     // Copy index.html:
     //  - inserting the filename as the <title> and <h1>
     //  - Inserting the correct name of the javascript file
-    copyFile(path.join(templateDir, "index.html"),
-             path.join(targetDirectory, "index.html"),
+    copyFile(path.join(templateDir, "index.html"), 
+             path.join(targetDirectory, "index.html"), 
              (fileContent) => {
         fileContent = fileContent.replace(/##STORY TITLE##/g, storyTitle);
         fileContent = fileContent.replace(/##JAVASCRIPT FILENAME##/g, this.jsFilename());
@@ -410,13 +410,13 @@ InkProject.prototype.buildForWeb = function(jsonFilePath, targetDirectory) {
     });
 
     // Copy other files verbatim
-    copyFile(path.join(__dirname, "../node_modules/inkjs/dist/ink.js"),
+    copyFile(path.join(__dirname, "../node_modules/inkjs/dist/ink.js"), 
              path.join(targetDirectory, "ink.js"));
 
-    copyFile(path.join(templateDir, "style.css"),
+    copyFile(path.join(templateDir, "style.css"), 
              path.join(targetDirectory, "style.css"));
 
-    copyFile(path.join(templateDir, "main.js"),
+    copyFile(path.join(templateDir, "main.js"), 
          path.join(targetDirectory, "main.js"));
 }
 
@@ -446,11 +446,11 @@ InkProject.prototype.tryClose = function() {
             }
 
             // Cancel
-            else {
+            else { 
                 ipc.send("project-cancelled-close");
             }
         });
-    }
+    } 
 
     // Nothing to save, just exit
     else {
@@ -542,7 +542,7 @@ InkProject.prototype.findSymbol = function(name, posContext) {
             }
         }
     }
-
+    
     if( !baseSymbol ) {
         console.log("Failed to find base symbol: "+baseName);
         return null;
@@ -557,7 +557,7 @@ InkProject.prototype.findSymbol = function(name, posContext) {
             console.log("Failed to find complete path due to not finding: "+tailComp);
             return symbol;
         }
-
+        
         symbol = tailSymbol;
     }
 

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -37,7 +37,7 @@ function InkProject(mainInkFilePath) {
 
 InkProject.prototype.createInkFile = function(anyPath) {
     var inkFile = new InkFile(anyPath || null, this.mainInk, {
-        fileChanged: () => { 
+        fileChanged: () => {
             if( inkFile.hasUnsavedChanges && !this.unsavedFiles.contains(inkFile) ) {
                 this.unsavedFiles.push(inkFile);
                 this.refreshUnsavedChanges();
@@ -49,7 +49,7 @@ InkProject.prototype.createInkFile = function(anyPath) {
         },
 
         // Called when InkFile finds an INCUDE line in the contents of the file
-        includesChanged: () => {         
+        includesChanged: () => {
             this.refreshIncludes();
             if( inkFile.includes.length > 0  )
                 NavView.initialShow();
@@ -243,7 +243,7 @@ function copyFile(source, destination, transform) {
         if( !err && fileContent ) {
             if( transform ) fileContent = transform(fileContent);
             if( fileContent.length < 1 ) throw "Trying to write (copy) empty file!";
-            
+
             fs.writeFile(destination, fileContent, "utf8");
         }
     });
@@ -297,7 +297,7 @@ InkProject.prototype.export = function(exportType) {
         }
 
         dialog.showSaveDialog(remote.getCurrentWindow(), saveOptions, (targetSavePath) => {
-            if( targetSavePath ) { 
+            if( targetSavePath ) {
                 this.defaultExportPath = targetSavePath;
 
                 // JSON export - simply move compiled json into place
@@ -317,10 +317,10 @@ InkProject.prototype.export = function(exportType) {
                             }
                         }
 
-                        // JS file: 
+                        // JS file:
                         if( exportType == "js" ) {
                             this.convertJSONToJS(compiledJsonTempPath, targetSavePath);
-                        } 
+                        }
 
                         // JSON: Just copy into place
                         else {
@@ -381,7 +381,7 @@ InkProject.prototype.buildForWeb = function(jsonFilePath, targetDirectory) {
 
     // Derive story title from save name
     var storyTitle = path.basename(targetDirectory);
-    
+
     // Unless the writer explicitly provided a tag with the title
     var mainInkTagDict = this.mainInk.symbols.globalDictionaryStyleTags;
     if( mainInkTagDict && mainInkTagDict["title"] ) {
@@ -398,8 +398,8 @@ InkProject.prototype.buildForWeb = function(jsonFilePath, targetDirectory) {
     // Copy index.html:
     //  - inserting the filename as the <title> and <h1>
     //  - Inserting the correct name of the javascript file
-    copyFile(path.join(templateDir, "index.html"), 
-             path.join(targetDirectory, "index.html"), 
+    copyFile(path.join(templateDir, "index.html"),
+             path.join(targetDirectory, "index.html"),
              (fileContent) => {
         fileContent = fileContent.replace(/##STORY TITLE##/g, storyTitle);
         fileContent = fileContent.replace(/##JAVASCRIPT FILENAME##/g, this.jsFilename());
@@ -407,13 +407,13 @@ InkProject.prototype.buildForWeb = function(jsonFilePath, targetDirectory) {
     });
 
     // Copy other files verbatim
-    copyFile(path.join(__dirname, "../node_modules/inkjs/dist/ink.js"), 
+    copyFile(path.join(__dirname, "../node_modules/inkjs/dist/ink.js"),
              path.join(targetDirectory, "ink.js"));
 
-    copyFile(path.join(templateDir, "style.css"), 
+    copyFile(path.join(templateDir, "style.css"),
              path.join(targetDirectory, "style.css"));
 
-    copyFile(path.join(templateDir, "main.js"), 
+    copyFile(path.join(templateDir, "main.js"),
          path.join(targetDirectory, "main.js"));
 }
 
@@ -443,11 +443,11 @@ InkProject.prototype.tryClose = function() {
             }
 
             // Cancel
-            else { 
+            else {
                 ipc.send("project-cancelled-close");
             }
         });
-    } 
+    }
 
     // Nothing to save, just exit
     else {
@@ -538,7 +538,7 @@ InkProject.prototype.findSymbol = function(name, posContext) {
             }
         }
     }
-    
+
     if( !baseSymbol ) {
         console.log("Failed to find base symbol: "+baseName);
         return null;
@@ -553,7 +553,7 @@ InkProject.prototype.findSymbol = function(name, posContext) {
             console.log("Failed to find complete path due to not finding: "+tailComp);
             return symbol;
         }
-        
+
         symbol = tailSymbol;
     }
 


### PR DESCRIPTION
This pull request resolves #29 and #21 by implementing a custom completer for Inky. This replaces the `textCompleter` included by default in ACE, which was causing headaches for some people by suggesting every word from the text (including _punctuation_) as an auto-complete suggestion.

`inkCompleter` pulls flow-control symbol names from `InkFileSymbols`. `InkFileSymbols` has also been upgraded to parse out variable names, which are likewise used by the completer to provide suggestions. `inkCompleter` will pull suggestions from all files in the current project, not just the current file.

In addition to suggestions generated by `inkCompleter` based on the user's source files, `ace-ink-mode` now provides Ink keywords as suggested completions, which are then supplied to the auto-completer by ACE's built-in `keyWordCompleter`.

Explicitly not covered by this pull request:

- Tags. I'm not sure how they're used, since they're not covered by [Writing With Ink](https://github.com/inkle/ink/blob/master/Documentation/WritingWithInk.md), so I didn't feel comfortable making the call as to whether they should be included in the suggestions. Since `InkFileSymbols` already parses them, adding them to `inkCompleter` later &mdash; if desired &mdash; should be simple enough.
- Determining which files in the current project are actually included by the current source file. Right now, `inkCompleter` provides suggestions based on all files that are currently in the project.

## TODO List
Based on the discussion that follows.

- [x] Pull in prose suggestions
- [x] Make completer context-aware to only suggest appropriate completions for the current cursor location
- [x] Add LISTs to `InkFileSymbols` as variable names
- [x] Add LIST name parsing to `ace-ink`
- [x] Suggest known knot names when writing a new knot, to support the "write divert first, knot second" workflow.
- [x] Make suggestion-generation asynchronous.