### PR TITLE
fix frontend infinite recursion when doing a circular inclusion

### DIFF
--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -101,10 +101,12 @@ InkProject.prototype.refreshIncludes = function() {
             return;
 
         inkFile.includes.forEach(incPath => {
+            let alreadyDone = relPathsFromINCLUDEs.contains(incPath);
+
             relPathsFromINCLUDEs.push(incPath);
 
             var recurseInkFile = this.inkFileWithRelativePath(incPath);
-            if( recurseInkFile )
+            if( recurseInkFile && !alreadyDone )
                 addIncludePathsFromFile(recurseInkFile);
         });
     }


### PR DESCRIPTION
I stumbled upon #132 (which is actually a duplicate of #110) when coding for #133.
This only prevent Inky from freezing, and thus displays the inclusion error on the side.