### PR TITLE
Display TODOs in edge case with zero content before choices

### DIFF
--- a/app/main-process/inklecate.js
+++ b/app/main-process/inklecate.js
@@ -167,6 +167,7 @@ function compile(compileInstruction, requester) {
                     text: choiceMatches[2]
                 }, sessionId);
             } else if( promptMatches ) {
+                sendAnyErrors();
                 if( session.evaluatingExpression )
                     session.evaluatingExpression = false;
                 else if( session.justRequestedDebugSource )

--- a/app/test/test.js
+++ b/app/test/test.js
@@ -107,5 +107,15 @@ describe('compiles hello world game', function () {
       .getText('.storyText:nth-of-type(2)')
       .should.eventually.equal(resultAnswer)
   })
+
+  it('shows TODOs', function() {
+    const input = "-\n * Rock\n * Paper\n * Scissors\nTODO: Make this more interesting"
+
+    return this.app.client
+      .setValue('.ace_text-input', input)
+      .pause(2000)
+      .getText('.issuesMessage')
+      .should.eventually.not.equal('No issues.')
+  })
 })
 


### PR DESCRIPTION
I noticed a small edge case in inky. If you have zero output before your set of choices, and no errors, TODOs won't show up. Example ink to demonstrate this:

```
-
* Rock
* Paper
* Scissors

TODO: Make this more interesting
```

This fixes it by making sure we flush errors to the UI once we encounter the prompt line. Since `sendAnyErrors` does nothing if we have no new errors, I don't believe there is any fear of losing errors flushed previously in the run.