### PR TITLE
Fix for \#tag highlighting

### DIFF
--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -401,7 +401,7 @@ var inkHighlightRules = function() {
         }],
         "#tags": [{
             token: "tag",
-            regex: /#.*/
+            regex: /(?:(?!\\).|^)#.*/
         }],
         "#mixedContent": [{
             include: "#inlineConditional"


### PR DESCRIPTION
This regex tweak supports highlight skip for \#tag while retaining highlights for #tag as you would expect.