### PR TITLE
\#tag fix attempt #2

### DIFF
--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -410,7 +410,7 @@ var inkHighlightRules = function() {
         }, {
             // e.g. #tag should be highlighted
             token: "tag",
-            regex: /(?:(?!\\).|^)#.*/
+            regex: /#.*/
         }],
         "#mixedContent": [{
             include: "#inlineConditional"

--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -400,6 +400,15 @@ var inkHighlightRules = function() {
             regex: /\s*~\s*.*$/
         }],
         "#tags": [{
+            // e.g. \\#tag should be highlighted
+            token: "doubleescape",
+            regex: /\\\\/
+        }, {
+            // e.g. \#tag should not be highlighted
+            token: "escape",
+            regex: /\\#/
+        }, {
+            // e.g. #tag should be highlighted
             token: "tag",
             regex: /#.*/
         }],


### PR DESCRIPTION
It was difficult to research exactly how to use Ace's highlighting system, but I believe this close to the proper way.

One improvement would be to move this escape sequence out to... someplace, but I have no idea where it should go. I tried putting it after the comment section, but no dice.

Someone who knows more than I do can make a more general purpose escape token, but this should work for this specific instance.