### PR TITLE
Fix '~' and '\{' and '\}' highlighting

### DIFF
--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -82,6 +82,10 @@ var inkHighlightRules = function() {
                 defaultToken: "choice"
             }]
         }],
+        "#escapes": [{
+            token: "escape",
+            regex: /\\[()\\~{}\/#]/
+        }],
         "#comments": [{
             token: "punctuation.definition.comment.json",
             regex: /\/\*\*/,
@@ -194,14 +198,31 @@ var inkHighlightRules = function() {
         }],
 
         "#gather": [{
-            regex: /^(\s*)((?:-\s*)+)(?!>)(?:(\(\s*)(\w+)(\s*\)))?/,
+            regex: /^(\s*)((?:-\s*)+)/,
             token: [
                 "gather", // whitespace
                 "gather.bullets", // - - 
-                "gather.label", // (
-                "gather.label.name", // label_name
-                "gather.label" // )
-            ]
+            ],
+            push: [{
+                regex: /$/,
+                token: "gather",
+                next: "pop"
+            }, {
+                include: "#escapes"
+            }, {
+                include: "#comments"
+            }, {
+                include: "#logicLineInsert"
+            }, {
+                regex: /(\(\s*)(\w+)(\s*\)\s*)/,
+                token: [
+                    "gather.label", // (
+                    "gather.label.name", // label_name
+                    "gather.label" // )
+                ],
+            }, {
+                defaultToken: "gather.innerContent"
+            }]
         }],
         "#globalVAR": [{
             regex: /^(\s*)(VAR|CONST)\b/, // (\s*)(\w+)(\s*)
@@ -225,6 +246,8 @@ var inkHighlightRules = function() {
                 token: "var-decl",
                 next: "pop"
             }, {
+                include: "#comments"
+            }, {
                 defaultToken: "var-decl"
             }]
         }],
@@ -234,20 +257,17 @@ var inkHighlightRules = function() {
                 "list-decl", // whitespace
                 "list-decl.keyword"
             ],
-            push: [
-                {
+            push: [ {
                     regex: /(\w+)(\s*=\s*)/,
                     token: [
                         "list-decl.name",
                         "list-decl" // whitespace & equals sign
                     ],
                     next: "#listItem"
-                },
-                {
+                }, {
                     regex: /$/,
                     next: "pop"
-                },
-                {
+                }, {
                     defaultToken: "list-decl"
                 }
             ]
@@ -369,7 +389,7 @@ var inkHighlightRules = function() {
         }],
         "#multiLineLogic": [{
             // e.g. \\{this = 5} // should not be highlighted
-            token: "doubleescape",
+            token: "escape",
             regex: /\\\\/
         }, {
             // e.g. \{this = 5\} // should not be highlighted
@@ -405,20 +425,47 @@ var inkHighlightRules = function() {
         }],
         "#logicLine": [{
             token: "logic.tilda",
-            regex: /^\s*~\s*.*$/
+            regex: /^\s*~\s*/,
+            push: [{
+                token: "logic.tilda",
+                regex: /$/,
+                next: "pop"
+            }, {
+                include: "#escapes"
+            }, {
+                include: "#comments"
+            }, {
+                defaultToken: "logic.tilda"
+            }]
+        }],
+        "#logicLineInsert": [{
+            token: "logic.tilda",
+            regex: /\s*~\s*/,
+            push: [{
+                token: "logic.tilda",
+                regex: /$/,
+                next: "pop"
+            }, {
+                include: "#escapes"
+            }, {
+                include: "#comments"
+            }, {
+                defaultToken: "logic.tilda"
+            }]
         }],
         "#tags": [{
-            // e.g. \\#tag should be highlighted
-            token: "doubleescape",
-            regex: /\\\\/
-        }, {
-            // e.g. \#tag should not be highlighted
-            token: "escape",
-            regex: /\\#/
-        }, {
             // e.g. #tag should be highlighted
             token: "tag",
-            regex: /#.*/
+            regex: /#/,
+            push: [{
+                token:"tag",
+                regex: /$/,
+                next: "pop"
+            }, {
+                include: "#comments"
+            }, {
+                defaultToken: "tag.innerContent"
+            }]
         }],
         "#mixedContent": [{
             include: "#inlineConditional"
@@ -426,8 +473,6 @@ var inkHighlightRules = function() {
             include: "#inlineSequence"
         }, {
             include: "#inlineLogic"
-        }, {
-            include: "#logicLine"
         }, {
             include: "#divert"
         }, {
@@ -438,6 +483,8 @@ var inkHighlightRules = function() {
         }],
         "#statements": [{
             include: "#comments"
+        }, {
+            include: "#escapes"
         }, {
             include: "#TODO"
         }, {

--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -66,6 +66,8 @@ var inkHighlightRules = function() {
                 regex: /$/,
                 next: "pop"
             }, {
+                include: "#escapes"
+            }, {
                 include: "#comments"
             }, {
                 token: [
@@ -84,7 +86,7 @@ var inkHighlightRules = function() {
         }],
         "#escapes": [{
             token: "escape",
-            regex: /\\[()\\~{}\/#]/
+            regex: /\\[\[\]()\\~{}\/#*+-]/
         }],
         "#comments": [{
             token: "punctuation.definition.comment.json",
@@ -198,7 +200,7 @@ var inkHighlightRules = function() {
         }],
 
         "#gather": [{
-            regex: /^(\s*)((?:-\s*)+)/,
+            regex: /^(\s*)((?:-(?!>)\s*)+)/,
             token: [
                 "gather", // whitespace
                 "gather.bullets", // - - 
@@ -220,6 +222,8 @@ var inkHighlightRules = function() {
                     "gather.label.name", // label_name
                     "gather.label" // )
                 ],
+            }, {
+                include: "#mixedContent"
             }, {
                 defaultToken: "gather.innerContent"
             }]
@@ -388,14 +392,6 @@ var inkHighlightRules = function() {
             }]
         }],
         "#multiLineLogic": [{
-            // e.g. \\{this = 5} // should not be highlighted
-            token: "escape",
-            regex: /\\\\/
-        }, {
-            // e.g. \{this = 5\} // should not be highlighted
-            token: "escape",
-            regex: /\\[{}]/
-        }, {
             regex: /^(\s*)(\{)(?:([^}:]+)(:))?(?=[^}]*$)/,
             token: [
                 "logic", // whitespace

--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -9,6 +9,8 @@ var inkHighlightRules = function() {
 
     this.$rules = {
         start: [{
+            include: "#escapes"
+        }, {
             include: "#comments"
         }, {
             regex: /^(\s*)(={2,})(\s*)((?:function)?)(\s*)(\w+)(\s*)(\([\w,\s->]*\))?(\s*)((?:={1,})?)/,
@@ -35,10 +37,6 @@ var inkHighlightRules = function() {
                 "flow.stitch.declaration.parameters" // parameters
             ]
         }, {
-            include: "#choice"
-        }, {
-            include: "#gather"
-        }, {
             include: "#statements"
         }],
         "#TODO": [{
@@ -50,7 +48,7 @@ var inkHighlightRules = function() {
             ]
         }],
         "#choice": [{
-            regex: /^(\s*)((?:[\*\+]\s?)+)(\s*)(?:(\(\s*)(\w+)(\s*\)))?/,
+            regex: /(\s*)((?:[\*\+]\s?)+)(\s*)(?:(\(\s*)(\w+)(\s*\)))?/,
             token: [
                 "choice", // whitespace
                 "choice.bullets", // * or +
@@ -66,18 +64,17 @@ var inkHighlightRules = function() {
                 regex: /$/,
                 next: "pop"
             }, {
-                include: "#escapes"
-            }, {
-                include: "#comments"
-            }, {
-                token: [
-                    "choice.weaveBracket",
-                    "choice.weaveInsideBrackets",
-                    "choice.weaveBracket"
-                ],
-                regex: /(\[)([^\]]*)(\])/
-            }, {
-                include: "#divert"
+                token: "choice.weaveBracket", 
+                regex: /\s*\[\s*/,                  // [ weave start 
+                push: [{ 
+                    token: "choice.weaveBracket", 
+                    regex: /\s*\]\s*/,              // ] weave end 
+                    next: "pop" 
+                }, {
+                    include: "#inlineContent" 
+                }, {
+                    defaultToken: "choice.weaveInsideBrackets" 
+                }]
             }, {
                 include: "#mixedContent"
             }, {
@@ -224,6 +221,8 @@ var inkHighlightRules = function() {
                 ],
             }, {
                 include: "#mixedContent"
+            }, {
+                defaultToken: "choice"
             }, {
                 defaultToken: "gather.innerContent"
             }]
@@ -463,12 +462,15 @@ var inkHighlightRules = function() {
                 defaultToken: "tag.innerContent"
             }]
         }],
-        "#mixedContent": [{
+        "#inlineContent": [{ 
             include: "#inlineConditional"
         }, {
             include: "#inlineSequence"
         }, {
             include: "#inlineLogic"
+        }], 
+        "#mixedContent": [{ 
+            include: "#inlineContent" 
         }, {
             include: "#divert"
         }, {

--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -16,25 +16,25 @@ var inkHighlightRules = function() {
             regex: /^(\s*)(={2,})(\s*)((?:function)?)(\s*)(\w+)(\s*)(\([\w,\s->]*\))?(\s*)((?:={1,})?)/,
             token: [
                 "",
-                "flow.knot.declaration.punctuation", // ===
-                "flow.knot.declaration", // whitespace
-                "flow.knot.declaration.function", // function (optional)
-                "flow.knot.declaration", // whitespace
-                "flow.knot.declaration.name", // knot_name
-                "flow.knot.declaration", // whitespace
-                "flow.knot.declaration.parameters", // (arg1, arg2)
-                "flow.knot.declaration", // whitespace
-                "flow.knot.declaration.punctuation" // ====
+                "flow.knot.declaration.punctuation",  // ===
+                "flow.knot.declaration",              // whitespace
+                "flow.knot.declaration.function",     // function (optional)
+                "flow.knot.declaration",              // whitespace
+                "flow.knot.declaration.name",         // knot_name
+                "flow.knot.declaration",              // whitespace
+                "flow.knot.declaration.parameters",   // (arg1, arg2)
+                "flow.knot.declaration",              // whitespace
+                "flow.knot.declaration.punctuation"   // ====
             ]
         }, {
             regex: /^(\s*)(=)(\s*)(\w+)(\s*)(\([\w,\s->]*\))?/,
             token: [
-                "flow.stitch.declaration", // whitespace
+                "flow.stitch.declaration",             // whitespace
                 "flow.stitch.declaration.punctuation", // =
-                "flow.stitch.declaration", // whitespace
-                "flow.stitch.declaration.name", // stitch_name
-                "flow.stitch.declaration", // whitespace
-                "flow.stitch.declaration.parameters" // parameters
+                "flow.stitch.declaration",             // whitespace
+                "flow.stitch.declaration.name",        // stitch_name
+                "flow.stitch.declaration",             // whitespace
+                "flow.stitch.declaration.parameters"   // parameters
             ]
         }, {
             include: "#statements"
@@ -42,20 +42,20 @@ var inkHighlightRules = function() {
         "#TODO": [{
             regex: /^(\s*)(TODO\b)(.*)/,
             token: [
-                "todo", // whitespace
-                "todo.TODO", // TODO
-                "todo" // user text
+                "todo",         // whitespace
+                "todo.TODO",    // TODO
+                "todo"          // user text
             ]
         }],
         "#choice": [{
             regex: /(\s*)((?:[\*\+]\s?)+)(\s*)(?:(\(\s*)(\w+)(\s*\)))?/,
             token: [
-                "choice", // whitespace
-                "choice.bullets", // * or +
-                "choice", // whitespace
-                "choice.label", // ( 
-                "choice.label.name", // label_name
-                "choice.label" // )
+                "choice",                           // whitespace
+                "choice.bullets",                   // * or +
+                "choice",                           // whitespace
+                "choice.label",                     // ( 
+                "choice.label.name",                // label_name
+                "choice.label"                      // )
             ],
 
             // Sub section within choice
@@ -83,24 +83,24 @@ var inkHighlightRules = function() {
         }],
         "#escapes": [{
             token: "escape",
-            regex: /\\[\[\]()\\~{}\/#*+-]/
+            regex: /\\[\[\]()\\~{}\/#*+-]/  // backslash escape sequences (e.g. \\ or \[ or \] or \~ or \#)
         }],
         "#comments": [{
             token: "punctuation.definition.comment.json",
-            regex: /\/\*\*/,
+            regex: /\/\*\*/,            // /** comment block
             push: [{
                 token: "punctuation.definition.comment.json",
-                regex: /\*\//,
+                regex: /\*\//,          // end comment block */
                 next: "pop"
             }, {
                 defaultToken: "comment.block.documentation.json"
             }]
         }, {
             token: "punctuation.definition.comment.json",
-            regex: /\/\*/,
+            regex: /\/\*/,              // /* comment block 
             push: [{
                 token: "punctuation.definition.comment.json",
-                regex: /\*\//,
+                regex: /\*\//,          // end comment block */
                 next: "pop"
             }, {
                 defaultToken: "comment.block.json"
@@ -110,7 +110,7 @@ var inkHighlightRules = function() {
                 "punctuation.definition.comment.json",
                 "comment.line.double-slash.js"
             ],
-            regex: /(\/\/)(.*$)/
+            regex: /(\/\/)(.*$)/        // // comment
         }],
 
         // Try different types of divert in sequence, since it's a bit complicated
@@ -170,7 +170,7 @@ var inkHighlightRules = function() {
             token: [
                 "divert.operator",  // -> | <-
                 "divert",           // whitespace
-                "divert.target",              // target.name
+                "divert.target",    // target.name
                 "divert"            // whitespace
             ]
         }, {
@@ -199,7 +199,7 @@ var inkHighlightRules = function() {
         "#gather": [{
             regex: /^(\s*)((?:-(?!>)\s*)+)/,
             token: [
-                "gather", // whitespace
+                "gather",         // whitespace
                 "gather.bullets", // - - 
             ],
             push: [{
@@ -215,14 +215,14 @@ var inkHighlightRules = function() {
             }, {
                 regex: /(\(\s*)(\w+)(\s*\)\s*)/,
                 token: [
-                    "gather.label", // (
+                    "gather.label",      // (
                     "gather.label.name", // label_name
-                    "gather.label" // )
+                    "gather.label"       // )
                 ],
             }, {
-                include: "#mixedContent"
+                include: "#choice"
             }, {
-                defaultToken: "choice"
+                include: "#mixedContent"
             }, {
                 defaultToken: "gather.innerContent"
             }]
@@ -237,9 +237,9 @@ var inkHighlightRules = function() {
             push: [{
                 regex: /(\s*)(\w+)(\s*)/,
                 token: [
-                    "var-decl", // whitespace
-                    "var-decl.name",
-                    "var-decl" // whitespace
+                    "var-decl",      // whitespace
+                    "var-decl.name", // var_name
+                    "var-decl"       // whitespace
                 ]
             }, 
 
@@ -257,14 +257,14 @@ var inkHighlightRules = function() {
         "#listDef": [{
             regex: /(\s*)(LIST)/,
             token: [
-                "list-decl", // whitespace
-                "list-decl.keyword"
+                "list-decl",          // whitespace
+                "list-decl.keyword"   // LIST
             ],
             push: [ {
                     regex: /(\w+)(\s*=\s*)/,
                     token: [
-                        "list-decl.name",
-                        "list-decl" // whitespace & equals sign
+                        "list-decl.name", // list_name
+                        "list-decl"       // whitespace & equals sign
                     ],
                     next: "#listItem"
                 }, {
@@ -393,24 +393,24 @@ var inkHighlightRules = function() {
         "#multiLineLogic": [{
             regex: /^(\s*)(\{)(?:([^}:]+)(:))?(?=[^}]*$)/,
             token: [
-                "logic", // whitespace
-                "logic.punctuation", // {
-                "logic.conditional.multiline.condition", // optional initial condition
-                "logic.conditional.multiline.condition.punctuation" // :
+                "logic",                                             // whitespace
+                "logic.punctuation",                                 // {
+                "logic.conditional.multiline.condition",             // optional initial condition
+                "logic.conditional.multiline.condition.punctuation"  // :
             ],
             push: [{
-                token: "logic.punctuation",
-                regex: /\}/,
+                token: "logic.punctuation",                          // }
+                regex: /\}/, 
                 next: "pop"
             }, {
-                regex: /^\s*else\s*\:/,
-                token: "conditional.multiline.else"
+                regex: /^\s*else\s*\:/,             
+                token: "conditional.multiline.else"                  // else :
             }, {
                 regex: /^(\s*)(-)(?!>)((?:\s?[^:\{}]+):)?/,
                 token: [
-                    "logic.multiline.branch",
-                    "logic.multiline.branch.operator",
-                    "logic.multiline.branch.condition"
+                    "logic.multiline.branch",                       // whitespace
+                    "logic.multiline.branch.operator",              // - 
+                    "logic.multiline.branch.condition"              // 
                 ]
             }, {
                 include: "#statements"

--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -368,6 +368,14 @@ var inkHighlightRules = function() {
             }]
         }],
         "#multiLineLogic": [{
+            // e.g. \\{this = 5} // should not be highlighted
+            token: "doubleescape",
+            regex: /\\\\/
+        }, {
+            // e.g. \{this = 5\} // should not be highlighted
+            token: "escape",
+            regex: /\\[{}]/
+        }, {
             regex: /^(\s*)(\{)(?:([^}:]+)(:))?(?=[^}]*$)/,
             token: [
                 "logic", // whitespace
@@ -397,7 +405,7 @@ var inkHighlightRules = function() {
         }],
         "#logicLine": [{
             token: "logic.tilda",
-            regex: /\s*~\s*.*$/
+            regex: /^\s*~\s*.*$/
         }],
         "#tags": [{
             // e.g. \\#tag should be highlighted


### PR DESCRIPTION
Another tweak to text highlighting.

`~` just needed a `^` to invalidate it when there's anything in front of it on the line.

`\{` and `\}` use a solution similar to the fix for `\#`