### PR TITLE
Menu updates

### DIFF
--- a/app/main-process/appmenus.js
+++ b/app/main-process/appmenus.js
@@ -107,15 +107,11 @@ function setupMenus(callbacks) {
     {
       label: "View",
       submenu: [
-        {role: 'reload'},
-        {role: 'forcereload'},
-        {role: 'toggledevtools'},
+        {role: 'togglefullscreen'},
         {type: 'separator'},
         {role: 'resetzoom'},
         {role: 'zoomin'},
-        {role: 'zoomout'},
-        {type: 'separator'},
-        {role: 'togglefullscreen'}
+        {role: 'zoomout'}
       ]
     },
     {

--- a/app/main-process/appmenus.js
+++ b/app/main-process/appmenus.js
@@ -107,17 +107,15 @@ function setupMenus(callbacks) {
     {
       label: "View",
       submenu: [
-        {
-          label: 'Toggle Full Screen',
-          accelerator: process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
-          click(item, focusedWindow) {
-            if (focusedWindow)
-              focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
-          }
-        },
-        {
-          label: "TODO: zoom controls"
-        }
+        {role: 'reload'},
+        {role: 'forcereload'},
+        {role: 'toggledevtools'},
+        {type: 'separator'},
+        {role: 'resetzoom'},
+        {role: 'zoomin'},
+        {role: 'zoomout'},
+        {type: 'separator'},
+        {role: 'togglefullscreen'}
       ]
     },
     {

--- a/app/main-process/appmenus.js
+++ b/app/main-process/appmenus.js
@@ -189,12 +189,6 @@ function setupMenus(callbacks) {
       role: 'help',
       submenu: [
         {
-          label: 'Learn More',
-          click() {
-            inklecate("hello world");
-          }
-        },
-        {
           label: 'Show Documentation',
           click: callbacks.showDocs
         },


### PR DESCRIPTION
This PR adds in zoom in and zoom out controls, as well as switching to the predefined `togglefullscreen` role. Additionally, this PR removes the 'learn more' option that was requested for removal in https://github.com/inkle/inky/issues/69 .

### Before
![screen shot 2018-01-31 at 8 43 14 am](https://user-images.githubusercontent.com/6091219/35627630-77a01b66-0667-11e8-8bca-d528f16c2489.png)

<img width="351" alt="screen shot 2018-01-31 at 1 33 05 pm" src="https://user-images.githubusercontent.com/6091219/35640492-501499e0-068b-11e8-806e-977b1d199a47.png">


### After
![screen shot 2018-01-31 at 9 17 15 am](https://user-images.githubusercontent.com/6091219/35627652-91b6c626-0667-11e8-8a8c-ae738e3ac2d3.png)

<img width="350" alt="screen shot 2018-01-31 at 1 32 38 pm" src="https://user-images.githubusercontent.com/6091219/35640496-53c40a6c-068b-11e8-81de-96f88b9b8d0f.png">

