### PR TITLE
Updated building instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,49 +54,13 @@ To build the project:
 
 ### Linux
 
-Tested on a fresh **Ubuntu 16.04 LTS** VM installation (_equivalent processes should work for other distributions_)
+For building Inky on Linux, first install `npm` and `electron-packager`.
 
-* Install build tools
-
-`sudo apt-get install -y dkms build-essential linux-headers-generic linux-headers-$(uname -r)`
-
-* Pre-requisites
-
-`sudo apt install git`
-
-`sudo apt install curl`
-
-* Install node and npm
-
-`curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -`
-
-`sudo apt-get install -y nodejs`
-
-* Install mono as per http://www.mono-project.com/download/stable/#download-lin
-
-`sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF`
-
-`echo "deb http://download.mono-project.com/repo/ubuntu stable-xenial main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list`
-
-`sudo apt-get update`
-
-`sudo apt-get install mono-complete`
-
-* Clone the inky repo
-
-`git clone https://github.com/inkle/inky.git`
-
-* Test inklecate_win with mono (_should output usage info_)
-
-`mono app/main-process/ink/inklecate_win.exe`
-
-* Install and run inky
-
-`./INSTALL_AND_RUN.command`
-
-* For subsequent runs, if no npm packages have changed, launch inky as below (otherwise re-run previous step):
-
-`./RUN.command`
+```bash
+sudo apt install -y npm
+sudo npm install electron-packager -g
+```
+Then you can use the script `build-for-linux.sh`. Once the script finishes, you will find a executable file called `Inky` under `./Inky-linux-x64`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To build the project:
 For building Inky on Linux, first install `npm` and `electron-packager`.
 
 ```bash
-sudo apt install -y npm
+sudo apt install -y npm mono-complete
 sudo npm install electron-packager -g
 ```
 Then you can use the script `build-for-linux.sh`. Once the script finishes, you will find a executable file called `Inky` under `./Inky-linux-x64`.

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ To build the project:
 
 ### Linux
 
-For building Inky on Linux, first install `npm` and `electron-packager`.
+For building Inky on Linux, first install `npm`, `mono`, `nodejs` and `electron-packager`.
 
 ```bash
-sudo apt install -y npm mono-complete
+sudo apt install -y npm mono-complete nodejs
 sudo npm install electron-packager -g
 ```
 Then you can use the script `build-for-linux.sh`. Once the script finishes, you will find a executable file called `Inky` under `./Inky-linux-x64`.

--- a/build-for-linux.sh
+++ b/build-for-linux.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Clean
+rm -rf Inky-darwin-x64/
+rm -rf Inky-win32-x64/
+rm -rf Inky-win32-ia32/
+rm -rf Inky-linux-x64/
+rm -rf ReleaseUpload
+
+# Ensure that all dependencies are correctly/fully installed
+cd app && npm install && cd ..
+
+# Build for x64
+electron-packager app Inky --platform=linux \
+                           --arch=x64 \
+                           --icon=resources/Icon.icns \
+                           --extend-info=resources/info.plist \
+                           --prune \
+                           --asar.unpackDir="main-process/ink" \
+                           --ignore="inklecate_mac"


### PR DESCRIPTION
Hi,

I've updated the instructions that describe how to build Inky on Linux. It is for Ubuntu 18.04 but it will be easy to install in any other Linux distribution using the corresponding package manager.