### PR TITLE
Fixed ace marker highlights not being cleared when switching files

### DIFF
--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -160,6 +160,7 @@ exports.EditorView = {
         inkCompleter.inkFiles = inkFiles;
     },
     showInkFile: (inkFile) => {
+        clearErrors();
         editor.setSession(inkFile.getAceSession());
         editor.focus();
     },


### PR DESCRIPTION
This should address issue #24 