### PR TITLE
Zoom support for Inky!

### DIFF
--- a/app/main-process/appmenus.js
+++ b/app/main-process/appmenus.js
@@ -135,7 +135,14 @@ function setupMenus(callbacks) {
           submenu: themes
         },
         {
-          label: "TODO: zoom controls"
+          label: "Zoom (Increase) ",
+          accelerator: 'CmdOrCtrl+K',
+          click: callbacks.zoomIn
+        },
+        {
+          label: "Zoom (Decrease) ",
+          accelerator: 'CmdOrCtrl+L',
+          click: callbacks.zoomOut
         }
       ]
     },
@@ -273,7 +280,7 @@ function setupMenus(callbacks) {
         },
       ]
     });
-    
+
     var windowMenu = _.find(template, menu => menu.role == "window");
     windowMenu.submenu.push(
       {

--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -101,6 +101,18 @@ app.on('ready', function () {
         countWords: () => {
             var win = ProjectWindow.focused();
             if (win) win.countWords();
+        },
+        zoomIn: () => {
+          var win = ProjectWindow.focused();
+          if (win != null) {
+            win.zoom(2);
+          }
+        },
+        zoomOut: () => {
+          var win = ProjectWindow.focused();
+          if (win != null) {
+            win.zoom(-2);
+          }
         }
     });
 

--- a/app/main-process/projectWindow.js
+++ b/app/main-process/projectWindow.js
@@ -7,8 +7,8 @@ const Inklecate = require("./inklecate.js").Inklecate;
 const Menu = electron.Menu;
 
 const electronWindowOptions = {
-  width: 1300, 
-  height: 730, 
+  width: 1300,
+  height: 730,
   minWidth: 350,
   minHeight: 250,
   titleBarStyle: 'hidden',
@@ -97,10 +97,14 @@ ProjectWindow.prototype.openDevTools = function() {
     this.browserWindow.webContents.openDevTools();
 }
 
+ProjectWindow.prototype.zoom = function(amount) {
+    this.browserWindow.webContents.send('zoom', amount);
+}
+
 ProjectWindow.all = () => windows;
 
 ProjectWindow.createEmpty = function() {
-    return new ProjectWindow(); 
+    return new ProjectWindow();
 }
 
 ProjectWindow.focused = function() {

--- a/app/renderer/controller.js
+++ b/app/renderer/controller.js
@@ -259,3 +259,33 @@ ipc.on("change-theme", (event, newTheme) => {
         $(".window").removeClass("dark");
     }
 });
+
+ipc.on("zoom", (event, amount) => {
+
+    // Search manually for element by ID
+    // (jQuery wrapping mutates attributes!)
+    let editorEl = document.getElementById("editor");
+    let playerEl = document.getElementById("player");
+
+    let currentSize = editorEl.style.fontSize;
+
+    if(currentSize == "") {
+
+      if(amount > 0) {
+        currentSize = "14";
+      } else {
+        currentSize = "10";
+      }
+
+    } else {
+
+      currentSize = currentSize.substring(0, currentSize.length - 2);
+      currentSize = parseInt(currentSize);
+      currentSize += amount;
+
+    }
+
+    editorEl.style.fontSize = currentSize + "px";
+    playerEl.style.fontSize = currentSize + "px";
+
+});


### PR DESCRIPTION
Creates new menu options under View, "Zoom (Increase)" and "Zoom (Decrease)". Clicking either calls ProjectWindow.zoom() which, in turn, sends a IPC message to the renderer window on the event 'zoom' with the amount to zoom.

In the renderer window (Controller.js), this message is watched for and the reaction is to look for and change the fontSize properties of the elements with the id "#editor" and that of the id "#player". (For whatever reason, using jQuery to get elements can sometimes removed the 'style' property.)

Using accelerator settings, the text size can be zoomed through CmdOrCtrl+K, to increase, or CmdOrCtrl+L to decrease. The preferred options would have been to use CmdOrCtrl+Plus and CmdOrCtrl+Minus, but Electron does not have "Minus" as an available key code. (See https://electronjs.org/docs/api/accelerator).