### PR TITLE
External file changes and deletes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -38,6 +38,7 @@
     "inkjs": "^1.10.2",
     "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
-    "randomstring": "^1.1.5"
+    "randomstring": "^1.1.5",
+    "slash": "^3.0.0"
   }
 }

--- a/app/renderer/editorView.js
+++ b/app/renderer/editorView.js
@@ -173,6 +173,7 @@ exports.EditorView = {
         if( savedCursorPos ) {
             editor.moveCursorToPosition(savedCursorPos); 
             editor.scrollToRow(savedScrollRow);
+            editor.clearSelection();
         } 
     }
 };

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -189,8 +189,10 @@ InkProject.prototype.startFileWatching = function() {
 
         var inkFile = _.find(this.files, f => f.relativePath() == relPath);
         if( inkFile ) {
-            if( inkFile.justSaved )
+            if( inkFile.justSaved ) {
+                inkFile.justSaved = false;
                 return;
+            }
             
             //console.log("Changed %o", inkFile);
 


### PR DESCRIPTION
Two commits here.

First one: fixes fileWatcher in Windows. It was not working because chokidar does not support globs on Windows since v2 (Dec 29, 2017). This partially solves #184 .

Second: implements asking user if he wants to reload/delete unsaved file which was edited externally. This fully solves #184 .

If second commit is not suitable for main repo, please at least take first one, as it is essential for working on Windows.