### PR TITLE
Improve playerView behaviour

### DIFF
--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -195,9 +195,7 @@ function addChoice(choice, callback)
         // Remove any existing choices, and add a divider
         $(".choice").remove();
 
-        if (($textBuffer[0].lastChild == null) || ($textBuffer[0].lastChild.tagName != "HR")) {
-            $textBuffer.append("<hr/>");
-        }
+        addHorizontalDivider();
 
         event.preventDefault();
 

--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -61,19 +61,41 @@ function fadeIn($jqueryElement) {
 
 function contentReady() {
 
-    // Expand to fit
-    var newHeight = $textBuffer[0].scrollHeight;
-    if( $textBuffer.height() < newHeight )
-        $textBuffer.height(newHeight);
+    var $scrollContainer = $("#player .scrollContainer");
+    $scrollContainer.stop();
 
-    // Scroll to bottom?
+    // Need to save these ones because we are reseting height, so these are lost
+    var savedScrollTop = $scrollContainer.scrollTop();
+    var prevHeight = $textBuffer.height();
+
+    // Need to reset first, otherwise ($textBuffer[0].scrollHeight) is always not less than $textBuffer.height() and it only expands (bad when story has huge list of choises)
+    $textBuffer.height(0);
+    var newHeight = $textBuffer[0].scrollHeight;
+
+    // Expand to fit or keep same (we will shrink it later, after animating scroll, this way scroll animation is prettier)
+    if( prevHeight < newHeight ) {
+        $textBuffer.height(newHeight);
+    } else {
+        $textBuffer.height(prevHeight);
+    }
+
+    // Scroll?
     if( shouldAnimate() ) {
-        var offset = newHeight - $("#player .scrollContainer").outerHeight();
-        if( offset > 0 && offset > $("#player .scrollContainer").scrollTop() ) {
-            $("#player .scrollContainer").animate({
-                scrollTop: offset
-            }, 500);
-        }
+        
+        var offset = newHeight + 60 - $scrollContainer.outerHeight(); // +60 because: ("#player .innerText { padding: 10px 0 50px 0; }")
+
+        // Need to set previous, as it was reset when we reset height
+        $scrollContainer.animate({scrollTop: savedScrollTop}, 0);
+
+        $scrollContainer.animate({
+            scrollTop: (offset)
+        }, 500, function(){
+            // Shrink, if needed
+            if( prevHeight > newHeight ) {
+                $textBuffer.height(newHeight);
+            }
+        });
+
     }
 }
 

--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -172,7 +172,10 @@ function addChoice(choice, callback)
 
         // Remove any existing choices, and add a divider
         $(".choice").remove();
-        $textBuffer.append("<hr/>");
+
+        if (($textBuffer[0].lastChild == null) || ($textBuffer[0].lastChild.tagName != "HR")) {
+            $textBuffer.append("<hr/>");
+        }
 
         event.preventDefault();
 
@@ -200,7 +203,9 @@ function addLongMessage(message, cssClass)
 
 function addHorizontalDivider()
 {
-    $textBuffer.append("<hr/>");
+    if (($textBuffer[0].lastChild == null) || ($textBuffer[0].lastChild.tagName != "HR")) {
+        $textBuffer.append("<hr/>");
+    }
 }
 
 function addLineError(error, callback)


### PR DESCRIPTION
Hello,

One minor change to not add duplicate `<hr/>` lines (this is prettier when choices do not print anything).

And one bigger change, that makes Inky behave MUCH better when story has huge list of choices (more than fits in screen):
- textBuffer.height can go shrink as well.
- Scroll top and down.

Previously, if a story had more choices than fits in the screen, then further on you would only see blank/white space after all the texts and choices, as textBuffer.height would never shrink and canvas would keep scrolling.

P. S. This is my first time working with node.js, so some things might be done not in the best way.