### PR TITLE
Fixed formatting for dark mode TODO highlighting

### DIFF
--- a/app/renderer/dark.css
+++ b/app/renderer/dark.css
@@ -99,7 +99,7 @@
 }
 
 .window.dark #editor .ace_todo,
-.window.dark #editor .ace-todo{
+.window.dark #editor .ace-todo {
     background: darkcyan;
 }
 

--- a/app/renderer/dark.css
+++ b/app/renderer/dark.css
@@ -98,6 +98,11 @@
     background: darkred;
 }
 
+.window.dark #editor .ace_todo,
+.window.dark #editor .ace-todo{
+    background: darkcyan;
+}
+
 .window.dark .ace_editor span.ace_flow.ace_declaration,
 .window.dark .ace_editor span.ace_divert,
 .window.dark .ace_editor span.ace_choice.ace_bullets,


### PR DESCRIPTION
Fixes #227 - TODO highlighting is now less bright and the TODO text is legible.

![image](https://user-images.githubusercontent.com/3412295/73989749-d0512400-493e-11ea-8858-eff9efed8679.png)
