### PR TITLE
Updated comment color to contrast logic color.

### DIFF
--- a/app/renderer/inkTheme.css
+++ b/app/renderer/inkTheme.css
@@ -13,6 +13,11 @@
   color: blue;
 }
 
+/* Comments */
+.ace-tm .ace_comment {
+  color: #bb5018;
+}
+
 /* Logic */
 .ace_editor span.ace_var-decl,
 .ace_editor span.ace_list-decl,


### PR DESCRIPTION
The current color of comments imported from Ace editor and logic color from inkTheme.css blend together with there subtle difference of green. This is a proposed auburn (reddish-brown) color to comments that contrast well from logic coloring and works with the current Light and Dark theme.

**Proposed Change (Light Theme):**
![image](https://user-images.githubusercontent.com/3943649/74002461-5b74ee80-492c-11ea-965f-e49454280f87.png)

**Proposed Change (Dark Theme):**
![image](https://user-images.githubusercontent.com/3943649/74002469-5fa10c00-492c-11ea-9f9a-4b3811e8a47f.png)

For reference to current implementation.

**Current (Light Theme):**
![image](https://user-images.githubusercontent.com/3943649/74002519-90814100-492c-11ea-8a24-cf5a4d51ecda.png)

**Current (Dark Theme):**
![image](https://user-images.githubusercontent.com/3943649/74002522-94ad5e80-492c-11ea-8ab3-ad2959298153.png)

Another reason for proposing a different color all together is due to monitor color calibrations between various monitors these current shades of green can contrast well enough or seem identical.

Resolves #201 
