### PR TITLE
Hotfix - placeholder comments to prevent blank Include bug.

### DIFF
--- a/app/renderer/inkFile.js
+++ b/app/renderer/inkFile.js
@@ -46,7 +46,11 @@ function InkFile(anyPath, mainInkFile, events) {
 
     this.mainInkFile = mainInkFile;
 
-    this.aceDocument = new Document("");
+    // Create new Inky files with a comment already embedded placeholder comment.
+    // This is a temporary solution to prevent the "INCLUDE x" blank file destructive deletion
+    // issue, where saving automatically created blank files prevented properly saving and
+    // removed Included files without warning the user.
+    this.aceDocument = new Document("//Replace this comment with Ink and start writing!");
     this.aceSession = null;
 
     this.includes = [];


### PR DESCRIPTION
An attempt at preventing people from saving blank files in their Inky projects, by automatically including a placeholder comment at the beginning of every new file generated by Inky.

## Description of the bug

Quoting Furkle: " if you have blank files in your project and you save them, they disappear after you reopen, i'm not exactly sure why. the simple remediation is to never save a blank file and just put a comment, TODO, hello world, lorem, tag, whatever in it as a practice".

This is a common issue among new (and even experienced) users and results in many of them coming into discord asking why Inky ate their work. As a bug it's non-obvious and destructive (causing loss of work without an obvious reason).

https://github.com/inkle/inky/issues/197
https://discordapp.com/channels/329929050866843648/329929390358265857/691342891477499904
https://discordapp.com/channels/329929050866843648/623109387283595264/626403819097554944
(there are several more instances of this in the discord logs: this is a fairly regular occurrence that brings in a bunch of baffled users all the time)

What I suspect is a common pattern among users triggering this bug:
1. Start a new project or open an existing one.
2. Instantiate a bunch of new files by typing `INCLUDE x.ink`, `INCLUDE y.ink`, `INCLUDE z.ink`.
3. Continue working on the project.
4. Forget that a blank file exists in their project when saving, and therefore trigger the blank include bug.

### Solution

As suggested by Jon Ingold here: https://discordapp.com/channels/329929050866843648/471562851346153474/596703842599436295

"A quick fix our end would be to stick a todo at the top of any new include file to say “write something here!”

I have added a quick fix that slaps a comment at the top of every new include file saying `//Replace this comment with Ink and start writing!`

I defer to Inkle as to what this placeholder text should actually be.

The main downside of this solution is that it does not actually solve the bug: if the user was dogged enough to create a blank project file, or felt defiant and decided to erase the comment completely instead, they'd still probably encounter this bug. But I think these are fringe cases.

It also creates the placeholder comment in the main file when starting a new project. This is somewhat messy, but I feel, acceptable.
