### PR TITLE
Upgraded chokidar to fix high CPU usage

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
     "spectron": "^3.8.0"
   },
   "dependencies": {
-    "chokidar": "^2.0.4",
+    "chokidar": "^3.3.1",
     "fuzzaldrin-plus": "^0.5",
     "inkjs": "^1.10.2",
     "lodash": "^4.17.15",


### PR DESCRIPTION
A recent update to chokidar fixed an issue that caused high CPU usage on macOS when watching a directory that contains a large number of files, [as discussed here](https://github.com/paulmillr/chokidar/issues/447).

This might be the cause of issue #63