### PR TITLE
fade rule for immediate, not all, children of container

### DIFF
--- a/app/export-for-web-template/style.css
+++ b/app/export-for-web-template/style.css
@@ -140,7 +140,7 @@ img {
     display: none;
 }
 
-.container * {
+.container > * {
     opacity: 1.0;
     transition: opacity 1.0s;
 }


### PR DESCRIPTION
Fix for https://github.com/inkle/ink/issues/525 (which should've been opened against inky, not ink)