### PR TITLE
Fixed scrollbar corners being white in dark mode

### DIFF
--- a/app/renderer/dark.css
+++ b/app/renderer/dark.css
@@ -131,7 +131,10 @@
 	width: auto;
 }
 
-.window.dark *::-webkit-scrollbar-track {
+.window.dark *::-webkit-scrollbar-track,
+.window.dark *::-webkit-scrollbar-track-piece,
+.window.dark *::-webkit-scrollbar-corner,
+.window.dark *::-webkit-resizer {
 	background-color: #222;
 }
 


### PR DESCRIPTION
missed a few attributes that cause the corners where scrollbars met (like the preview pane) to be white while the rest of the scrollbar was dark.