### PR TITLE
Don't error if preview update is interrupted by window closure

### DIFF
--- a/app/main-process/inklecate.js
+++ b/app/main-process/inklecate.js
@@ -135,7 +135,7 @@ function compile(compileInstruction, requester) {
     }
 
     playProcess.stdout.on('data', (text) => {
-      
+
         // Strip Byte order mark
         text = text.replace(/^\uFEFF/, '');
         if( text.length == 0 ) return;

--- a/app/main-process/inklecate.js
+++ b/app/main-process/inklecate.js
@@ -196,16 +196,12 @@ function compile(compileInstruction, requester) {
                 // during compilation.
                 sendAnyErrors();
 
-                // try, because it can be destroyed while sending
-                try {
+								if (!requester.isDestroyed()) {
                   if (session.evaluatingExpression ) {
                       requester.send('play-evaluated-expression', line, sessionId);
                   } else {
                       requester.send('play-generated-text', line, sessionId);
                   }
-                } catch (e) {
-                  if (!e.message.startsWith("Object has been destroyed"))
-                    throw e; // not expected
                 }
             }
 

--- a/app/main-process/inklecate.js
+++ b/app/main-process/inklecate.js
@@ -196,7 +196,7 @@ function compile(compileInstruction, requester) {
                 // during compilation.
                 sendAnyErrors();
 
-								if (!requester.isDestroyed()) {
+                if (!requester.isDestroyed()) {
                   if (session.evaluatingExpression ) {
                       requester.send('play-evaluated-expression', line, sessionId);
                   } else {

--- a/app/main-process/inklecate.js
+++ b/app/main-process/inklecate.js
@@ -135,7 +135,7 @@ function compile(compileInstruction, requester) {
     }
 
     playProcess.stdout.on('data', (text) => {
-
+			
         // Strip Byte order mark
         text = text.replace(/^\uFEFF/, '');
         if( text.length == 0 ) return;
@@ -196,12 +196,17 @@ function compile(compileInstruction, requester) {
                 // during compilation.
                 sendAnyErrors();
 
-                if( session.evaluatingExpression ) {
-                    requester.send('play-evaluated-expression', line, sessionId);
-                } else {
-                    requester.send('play-generated-text', line, sessionId);
-                }
-
+								// try, because it can be destroyed while sending
+								try {
+									if (session.evaluatingExpression ) {
+											requester.send('play-evaluated-expression', line, sessionId);
+									} else {
+											requester.send('play-generated-text', line, sessionId);
+									}
+								} catch (e) {
+									if (!e.message.startsWith("Object has been destroyed"))
+										throw e; // not expected
+								}
             }
 
         }

--- a/app/main-process/inklecate.js
+++ b/app/main-process/inklecate.js
@@ -135,7 +135,7 @@ function compile(compileInstruction, requester) {
     }
 
     playProcess.stdout.on('data', (text) => {
-			
+      
         // Strip Byte order mark
         text = text.replace(/^\uFEFF/, '');
         if( text.length == 0 ) return;
@@ -196,17 +196,17 @@ function compile(compileInstruction, requester) {
                 // during compilation.
                 sendAnyErrors();
 
-								// try, because it can be destroyed while sending
-								try {
-									if (session.evaluatingExpression ) {
-											requester.send('play-evaluated-expression', line, sessionId);
-									} else {
-											requester.send('play-generated-text', line, sessionId);
-									}
-								} catch (e) {
-									if (!e.message.startsWith("Object has been destroyed"))
-										throw e; // not expected
-								}
+                // try, because it can be destroyed while sending
+                try {
+                  if (session.evaluatingExpression ) {
+                      requester.send('play-evaluated-expression', line, sessionId);
+                  } else {
+                      requester.send('play-generated-text', line, sessionId);
+                  }
+                } catch (e) {
+                  if (!e.message.startsWith("Object has been destroyed"))
+                    throw e; // not expected
+                }
             }
 
         }


### PR DESCRIPTION
Fix #196  which isn't Linux-exclusive like I thought it was, reading the issue now.