### PR TITLE
Changed macOS handler rank

### DIFF
--- a/resources/Info.plist
+++ b/resources/Info.plist
@@ -12,7 +12,7 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
-			<string>Alternate</string>
+			<string>Owner</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Very small edit, just so Inky is for sure the default program to recommend and launch when opening .ink files on MacOS.

Resolves #258.