### PR TITLE
Changed grammar for word count alert

### DIFF
--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -631,8 +631,8 @@ InkProject.prototype.countWords = function() {
     };
 
     let n = recur(this.activeInkFile);
-    alert(`There ${n > 1 ? 'are' : 'is'} ${n.toLocaleString()} word${n > 1 ? 's' : ''} in this project.`);
-}
+    alert(`There ${n != 1 ? 'are' : 'is'} ${n.toLocaleString()} word${n != 1 ? 's' : ''} in this project.`);
+} 
 
 InkProject.setEvents = function(e) {
     InkProject.events = e;

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -631,7 +631,7 @@ InkProject.prototype.countWords = function() {
     };
 
     let n = recur(this.activeInkFile);
-    alert(`There is ${n.toLocaleString()} word${n > 1 ? 's' : ''} in this project.`);
+    alert(`There ${n > 1 ? 'are' : 'is'} ${n.toLocaleString()} word${n > 1 ? 's' : ''} in this project.`);
 }
 
 InkProject.setEvents = function(e) {


### PR DESCRIPTION
I did a tiny, likely unnecessary grammar fix on the word count alert while trying to figure out how the menu code works.

The code originally gives the following for 0, 1 and n > 1 words respectively:
"There is 0 word in this project."
"There is 1 word in this project."
"There is n words in this project."

Changed the alert so that it says:
"There are 0 words in this project."
"There is 1 word in this project."
"There are n words in this project."