### PR TITLE
Support # LINK and # LINKOPEN tags

### DIFF
--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -81,6 +81,16 @@
                     delay += 200.0;
                 }
 
+                // LINK: url
+                else if( splitTag && splitTag.property == "LINK" ) {
+                    window.location.href = splitTag.val;
+                }
+
+                // LINKOPEN: url
+                else if( splitTag && splitTag.property == "LINKOPEN" ) {
+                    window.open(splitTag.val);
+                }
+
                 // CLASS: className
                 else if( splitTag && splitTag.property == "CLASS" ) {
                     customClasses.push(splitTag.val);


### PR DESCRIPTION
Simple choice-to-tag-based external url support for the export template.
Requires that urls be escaped: `http:\/\/example.com`
Closes #265.