### PR TITLE
Tag-based audio

### DIFF
--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -71,6 +71,17 @@
                 // customised to be used for other things too.
                 var splitTag = splitPropertyTag(tag);
 
+                // AUDIO: src
+                else if( splitTag && splitTag.property == "AUDIO" ) {
+                  if('audio' in this) {
+                    this.audio.pause();
+                    this.audio.removeAttribute('src');
+                    this.audio.load();
+                  }
+                  this.audio = new Audio(splitTag.val);
+                  this.audio.play();
+                }
+
                 // IMAGE: src
                 if( splitTag && splitTag.property == "IMAGE" ) {
                     var imageElement = document.createElement('img');

--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -82,6 +82,18 @@
                   this.audio.play();
                 }
 
+                // AUDIOLOOP: src
+                else if( splitTag && splitTag.property == "AUDIOLOOP" ) {
+                  if('audioLoop' in this) {
+                    this.audioLoop.pause();
+                    this.audioLoop.removeAttribute('src');
+                    this.audioLoop.load();
+                  }
+                  this.audioLoop = new Audio(splitTag.val);
+                  this.audioLoop.play();
+                  this.audioLoop.loop = true;
+                }
+
                 // IMAGE: src
                 if( splitTag && splitTag.property == "IMAGE" ) {
                     var imageElement = document.createElement('img');


### PR DESCRIPTION
Simple tag-based audio control for the export template.
Separate channel for audio and looping audio, suitable for foreground and background events.
Supports both local files and escaped file urls: `http:\/\/foo.com/bar.mp3`

Closes #268