### PR TITLE
Tag-based background images

### DIFF
--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -91,6 +91,11 @@
                     window.open(splitTag.val);
                 }
 
+                // BACKGROUND: src
+                else if( splitTag && splitTag.property == "BACKGROUND" ) {
+                    outerScrollContainer.style.backgroundImage = 'url('+splitTag.val+')';
+                }
+
                 // CLASS: className
                 else if( splitTag && splitTag.property == "CLASS" ) {
                     customClasses.push(splitTag.val);

--- a/app/export-for-web-template/style.css
+++ b/app/export-for-web-template/style.css
@@ -82,11 +82,15 @@ h3.written-in-ink {
     top: 0;
     left: 0;
     margin-top: 24px;
+    background-size: cover;
+    background-repeat: no-repeat;
 }
 
 @media screen and (max-width: 980px) {
     .outerContainer {
         margin-top: 44px;
+        background-size: cover;
+        background-repeat: no-repeat;
     }
 }
 


### PR DESCRIPTION
Simple tag-based background image control for the export template.
Supports both local files and escaped image urls: `http:\/\/foo.com/bar.png`
Defaults to full size.

Closes #270
