### PR TITLE
Changed zoom out/in shortcut from Ctrl L/K to Ctrl -/=

### DIFF
--- a/app/main-process/appmenus.js
+++ b/app/main-process/appmenus.js
@@ -140,12 +140,12 @@ function setupMenus(callbacks) {
                 },
                 {
                     label: "Zoom (Increase) ",
-                    accelerator: 'CmdOrCtrl+K',
+                    accelerator: 'CmdOrCtrl+=',
                     click: callbacks.zoomIn
                 },
                 {
                     label: "Zoom (Decrease) ",
-                    accelerator: 'CmdOrCtrl+L',
+                    accelerator: 'CmdOrCtrl+-',
                     click: callbacks.zoomOut
                 }
             ]


### PR DESCRIPTION
When this feature was made Electron did not have "-" as an available key code so "L" and "K" were used as placeholders. Now that it is available we should use these new shortcut keys since they are more intuitive as they fall in line with every other application's zoom shortcut.