### PR TITLE
Fix an edge case when arg.length = 3

### DIFF
--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -129,8 +129,8 @@ app.on('ready', function () {
     let openedSpecificFile = false;
     if (process.platform == "win32" && process.argv.length > 1) {
         for (let i = 1; i < process.argv.length; i++) {
-            var arg = process.argv[i];
-            if (arg.indexOf(".ink") == arg.length - 4) {
+            var arg = process.argv[i].toLowerCase();
+            if (arg.endsWith(".ink")) {
                 var fileToOpen = process.argv[1];
                 ProjectWindow.open(fileToOpen);
                 openedSpecificFile = true;


### PR DESCRIPTION
when the length of arg is 3, the indexOf function will return -1 == arg.length - 4

```javascript
// arg = "123", then
arg.indexOf(".ink") == arg.length - 4
```