### PR TITLE
Added a more congenial dark theme

### DIFF
--- a/app/renderer/dark.css
+++ b/app/renderer/dark.css
@@ -1,7 +1,7 @@
 .window.dark #main,
 .window.dark #editor,
 .window.dark #toolbar {
-    background-color: #333;
+    background-color: #282828;
 }
 
 .window.dark #main .sidebar,
@@ -26,10 +26,6 @@
 
 .window.dark #main .sidebar .nav-group-item.active .filename {
     color: #CCC;
-}
-
-.window.dark .busySpinner {
-    background-image: url(img/busy-dark.gif);
 }
 
 .window.dark #toolbar .button:hover .icon {
@@ -74,7 +70,8 @@
 .window.dark #editor,
 .window.dark #player,
 .window.dark .ace_editor .ace_cursor {
-    color: #f0f0f0;
+    /*color: #f0f0f0; */
+    color: #faf1c6;
 }
 
 .window.dark .ace_editor .ace_indent-guide {
@@ -102,81 +99,36 @@
     background: darkred;
 }
 
-.window.dark #editor .ace-warning {
-    background-color: #7d6015;
-}
-
 .window.dark #editor .ace_todo,
 .window.dark #editor .ace-todo {
-    background: darkcyan;
+    background:#f2ad2b;
+    color: #784a0f;
 }
 
 .window.dark .ace_editor span.ace_flow.ace_declaration,
 .window.dark .ace_editor span.ace_divert,
-.window.dark .ace_editor span.ace_choice.ace_bullets,
 .window.dark .ace_editor span.ace_choice.ace_label,
-.window.dark .ace_editor span.ace_choice.ace_weaveBracket,
-.window.dark .ace_editor span.ace_gather.ace_bullets,
 .window.dark .ace_editor span.ace_gather.ace_label,
 .window.dark .ace_editor span.ace_glue,
 .window.dark .ace_editor span.ace_include,
 .window.dark .ace_editor span.ace_external {
-  color: cyan;
+    color:#6d9e8e;
+}
+
+.window.dark .ace_editor span.ace_choice.ace_bullets,
+.window.dark .ace_editor span.ace_choice.ace_weaveBracket,
+.window.dark .ace_editor span.ace_gather.ace_bullets {
+    color: #ec3c2f;
 }
 
 .window.dark .ace_editor span.ace_var-decl,
-.window.dark .ace_editor span.ace_list-decl,
+.window.dark .ace_editor span.ace_list-decl {
+    color: #ec3c2f;
+}
 .window.dark .ace_editor span.ace_logic:not(.ace_innerContent) {
-  color: lightgreen;
+    color:#8eb865;
 }
 
 .window.dark #main.hideTags .ace_editor span.ace_tag {
-    color: #333;
-}
-
-/* scrollbars */
-.window.dark *::-webkit-scrollbar {
-	width: auto;
-}
-
-.window.dark *::-webkit-scrollbar-track,
-.window.dark *::-webkit-scrollbar-track-piece,
-.window.dark *::-webkit-scrollbar-corner,
-.window.dark *::-webkit-resizer {
-	background-color: #222;
-}
-
-.window.dark *::-webkit-scrollbar-thumb {
-	background-color: #777;
-	transition: background-color 0.6s;
-	box-shadow: inset 0px 0px 10px 0px #00000061;
-}
-
-.window.dark *::-webkit-scrollbar-thumb:hover {
-	background-color: #999;
-	transition: background-color 0.6s;
-}
-
-/* Issues Pop-up */
-#toolbar .issue-popup {
-    background-color: #222;
-    border-color: #444;
-}
-
-#toolbar .issue-popup img.nubbin {
-    filter: brightness(12%);
-}
-
-#toolbar .issue-popup .row:hover {
-background: #444;
-}
-
-#toolbar .issue-popup .row {
-    border-bottom-color: #333;
-}
-
-#toolbar .issue-popup .line-no {
-    background: #222;
-    color: #ccc;
-    border-right-color: #333;
+    color: #282828;
 }

--- a/app/renderer/inkTheme.css
+++ b/app/renderer/inkTheme.css
@@ -1,7 +1,7 @@
 
 /* Flow related stuff in blue */
-.ace_editor span.ace_flow.ace_declaration, 
-.ace_editor span.ace_divert, 
+.ace_editor span.ace_flow.ace_declaration,
+.ace_editor span.ace_divert,
 .ace_editor span.ace_choice.ace_bullets,
 .ace_editor span.ace_choice.ace_label,
 .ace_editor span.ace_choice.ace_weaveBracket,
@@ -10,19 +10,19 @@
 .ace_editor span.ace_glue,
 .ace_editor span.ace_include,
 .ace_editor span.ace_external {
-  color: blue;
+    color: blue;
 }
 
 /* Comments */
 .ace-tm .ace_comment {
-  color: #bb5018;
+    color: #84756c;
 }
 
 /* Logic */
 .ace_editor span.ace_var-decl,
 .ace_editor span.ace_list-decl,
 .ace_editor span.ace_logic:not(.ace_innerContent) {
-  color: green;
+    color: green;
 }
 
 /* Tags */

--- a/app/renderer/main.css
+++ b/app/renderer/main.css
@@ -518,7 +518,7 @@ img.issue-icon.warning {
 }
 
 #editor .ace-warning {
-  background: #ffedbf;
+  background: #f2ad2b;
   position:absolute;
 }
 
@@ -727,7 +727,7 @@ img.issue-icon.warning {
 }
 
 #player td.expressionInput:focus {
-  outline: none; 
+  outline: none;
 }
 
 #player .evaluationResult {
@@ -779,7 +779,7 @@ img.issue-icon.warning {
   background-image: url(img/busy.gif);
   background-repeat: no-repeat;
   background-size: cover;
-  
+
 }
 
 #goto-anything {


### PR DESCRIPTION
User mrcsbmr created a more congenial dark mode for inky here:  https://gitlab.com/mrcsbmr/inky-theme.

mrcsbmr has graciously given permission for their work to be added to Inky, so I'm adding it here.

This is the old dark theme:
![image](https://user-images.githubusercontent.com/3412295/84290987-650d9d80-ab3c-11ea-8738-7ef97f7c88ae.png)

Compared with the new one:
![image](https://user-images.githubusercontent.com/3412295/84290930-49a29280-ab3c-11ea-9825-818bd5fcc799.png)

Opinion on the Ink discord seems to be unanimous that mrcsbmr's new dark theme is more pleasant to use in general. The user who implemented the original dark theme also prefers the new, spiffier theme 😄
