### PR TITLE
Keyboard shortcuts

### DIFF
--- a/app/main-process/appmenus.js
+++ b/app/main-process/appmenus.js
@@ -134,6 +134,14 @@ function setupMenus(callbacks) {
                     accelerator: 'CmdOrCtrl+A',
                     role: 'selectall'
                 },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: 'Useful Keyboard Shortcuts',
+                    enabled: callbacks.isFocusedWindow,
+                    click: callbacks.keyboardShortcuts
+                }
             ]
         },
         {

--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -99,6 +99,10 @@ app.on('ready', function () {
         showAbout: () => {
             AboutWindow.showAboutWindow(theme);
         },
+        keyboardShortcuts: () => {
+            var win = ProjectWindow.focused();
+            if (win) win.keyboardShortcuts();
+        },
         stats: () => {
             var win = ProjectWindow.focused();
             if (win) win.stats();

--- a/app/main-process/projectWindow.js
+++ b/app/main-process/projectWindow.js
@@ -87,6 +87,10 @@ ProjectWindow.prototype.stats = function() {
     this.browserWindow.webContents.send('project-stats');
 }
 
+ProjectWindow.prototype.keyboardShortcuts = function() {
+    this.browserWindow.webContents.send('keyboard-shortcuts');
+}
+
 ProjectWindow.prototype.finalClose = function() {
     this.safeToClose = true;
     Inklecate.killSessions(this.browserWindow);

--- a/app/renderer/controller.js
+++ b/app/renderer/controller.js
@@ -199,6 +199,28 @@ ipc.on("project-stats", (event, visible) => {
     });
 });
 
+ipc.on("keyboard-shortcuts", (event, visible) => {
+    let messageLines = [];
+    messageLines.push("Useful Keyboard Shortcuts");
+    messageLines.push("");
+    messageLines.push("Find and Replace: Ctrl+H or Cmd+H");
+    messageLines.push("");
+    messageLines.push("Find: Ctrl+F or Cmd+F");
+    messageLines.push("");
+    messageLines.push("Go to Anything: Ctrl+P or Cmd+P");
+    messageLines.push("");
+    messageLines.push("Toggle Comment: Ctrl+/ or Cmd+/");
+    messageLines.push("");
+    messageLines.push("Add Multicursor Above: Ctrl+Alt+Up or Ctrl+Option+Up");
+    messageLines.push("");
+    messageLines.push("Add Multicursor Below: Ctrl+Alt+Down or Ctrl+Option+Down");
+    messageLines.push("");
+    messageLines.push("Temporarily Fold/Unfold Selection: Alt+L or Ctrl+Option+Down");
+    messageLines.push("");
+    alert(messageLines.join("\n"));
+});
+
+
 EditorView.setEvents({
     "change": () => {
         LiveCompiler.setEdited();


### PR DESCRIPTION
We get a lot of people asking about Find and Replace in the Ink discord, which indicates it's not a feature that's very obviously surfaced.

Find and Replace in Inky does, in fact, exist, and is provided by the Ace editor that Inky is built on. It's just not on a very intuitive keyboard shortcut - Ctrl+H - and at the moment there's no way to know this except through trial and error keyboard mashing or by googling "Ace editor keyboard shortcuts", which...also isn't intuitive.

What I wanted to do was hook up Find and Replace to the menu directly, but unfortunately, after a day or so of trying to do this, I couldn't find a way to do this that was achievable by me, and/or wouldn't break the next time we updated the ace editor library!

So, rather than introducing a lot of spaghetti for a feature that already exists, I was thinking we could put a list of keyboard shortcuts in the place people will first look when searching for a Find and Replace function: in the edit menu. 

![image](https://user-images.githubusercontent.com/3412295/84580289-70c3c300-adcd-11ea-8c11-416ee0a86a60.png)

The menu that appears is ugly but functional, and should tell people everything they want to know about find and replace (and a bit more).

![image](https://user-images.githubusercontent.com/3412295/84580319-d912a480-adcd-11ea-8517-b426f3e49c55.png)

It's been implemented in the exact same way that the story stats menu option was, which you can see below here: 
![image](https://user-images.githubusercontent.com/3412295/84580329-f21b5580-adcd-11ea-971e-2ddc566ef892.png)

With luck, this should reduce the amount of people who need to go to the Ink discord to find out how to Find and Replace in Inky!
