### PR TITLE
Improve editor scrollbar visuals

### DIFF
--- a/app/renderer/dark.css
+++ b/app/renderer/dark.css
@@ -132,3 +132,17 @@
 .window.dark #main.hideTags .ace_editor span.ace_tag {
     color: #282828;
 }
+
+.window.dark ::-webkit-scrollbar {
+    width: .75rem;
+    background: #282828;
+    border-left: 1px solid #323232;
+  }
+  
+.window.dark ::-webkit-scrollbar-thumb {
+    background: #323232;
+}
+
+.window.dark .sidebar .nav-wrapper::-webkit-scrollbar-thumb {
+    background: #323232;
+}

--- a/app/renderer/main.css
+++ b/app/renderer/main.css
@@ -329,7 +329,7 @@ img.issue-icon.warning {
   bottom: 0;
   left: 0;
   right: 0;
-  overflow: scroll;
+  overflow: auto;
   padding-bottom: 40px; /* leave space for include adding UI */
 }
 
@@ -683,7 +683,8 @@ img.issue-icon.warning {
   left: 0;
   right: 0;
   bottom: 0;
-  overflow: scroll;
+  overflow-y: scroll;
+  overflow-x: auto;
 }
 
 #player .expressionWatch td {
@@ -879,4 +880,18 @@ img.issue-icon.warning {
 
 .ignore-events {
   pointer-events: none;
+}
+
+.window ::-webkit-scrollbar {
+  width: .75rem;
+  background: transparent;
+  border-left: 1px solid #F0F0F0;
+}
+
+.window ::-webkit-scrollbar-thumb {
+  background: #F0F0F0;
+}
+
+.sidebar .nav-wrapper::-webkit-scrollbar-thumb {
+  background: #DDDDDD;
 }


### PR DESCRIPTION
This set of CSS changes does the following:

* Scrollbars are now thinner and eschew the thumb buttons, reducing visual clutter
* **Scrollbars now become dark when dark theme is enabled.**
* The file navigation pane and play preview no longer have unnecessary scrollbars enabled by default