### PR TITLE
Fix broken jumps to sub-files on PC

### DIFF
--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -514,7 +514,7 @@ InkProject.prototype.closeImmediate = function() {
 }
 
 InkProject.prototype.inkFileWithRelativePath = function(relativePath) {
-    return _.find(this.files, f => f.relativePath() == relativePath);
+    return _.find(this.files, f => f.relativePath().replace('\\', '/') == relativePath);
 }
 
 InkProject.prototype.inkFileWithId = function(id) {


### PR DESCRIPTION
There is an bug on PC that doesn't allow error/warning jumps to go to sub-files (ink files in a sub-directory like `subfolder/test_file`). It just jumps to the correct line of whatever the current file is, since it can't find the right file.

The error is that on PC, the `file.relativePath()` returns a path with `\` instead of `/` which Inky expects, so when the relative path is checked, this fix swaps the `\` with `/`.