### PR TITLE
Show an ErrorBox when refusing to save because of blank files.

### DIFF
--- a/app/renderer/inkFile.js
+++ b/app/renderer/inkFile.js
@@ -176,7 +176,10 @@ InkFile.prototype.save = function(afterSaveCallback) {
     else {
         this.justSaved = true;
         var fileContent = this.aceDocument.getValue();
-        if( !fileContent || fileContent.length < 1 ) throw "Empty file content in aceDocument!";
+        if( !fileContent || fileContent.length < 1 ) {
+            dialog.showErrorBox("Refusing to save empty file", "\""+this.relPath+"\" is empty: please add some content.");
+            throw "Empty file content in aceDocument!";
+        }
         
         // Ensure that the enclosing folder exists beforehand
         var fileAbsPath = this.absolutePath();

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -288,8 +288,11 @@ function copyFile(source, destination, transform) {
     fs.readFile(source, "utf8", (err, fileContent) => {
         if( !err && fileContent ) {
             if( transform ) fileContent = transform(fileContent);
-            if( fileContent.length < 1 ) throw "Trying to write (copy) empty file!";
-            
+            if( fileContent.length < 1 ) {
+                dialog.showErrorBox("Refusing to copy empty file", "\""+source+"\" is empty: please add some content.");
+                throw "Trying to write (copy) empty file!";
+            }
+
             fs.writeFile(destination, fileContent, "utf8", err => {
                 if( err ) alert(`Failed to save file '${destination}'`);
             });


### PR DESCRIPTION
If we can't actually *fix* #150, can we at least tell users *why* their changes aren't being saved so the program isn't just being a complete utter total asshole and silently refusing to save their work?