### PR TITLE
Update Inky to watch files without any extension in addition to '.ink' files

### DIFF
--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -188,7 +188,8 @@ InkProject.prototype.startFileWatching = function() {
     });
 
     const isInkFile = fileAbsPath => {
-        return fileAbsPath.split(".").pop() == "ink";
+        var fileName = fileAbsPath.split('\\').pop().split('/').pop()
+        return !fileName.includes('.') || fileName.split(".").pop() == "ink";
     };
 
     this.fileWatcher.on("add", newlyFoundAbsFilePath => {


### PR DESCRIPTION
This also just checks the file name since folders could possibly include `.` in their name.