### PR TITLE
I18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ Tested on a fresh **Ubuntu 16.04 LTS** VM installation (_equivalent processes sh
 
 `./RUN.command`
 
+### Translation
+
+Translation files are located under `app/main-process/i18n/`.  
+If a particular locale file is missing (or if it's missing some keys), you can generate it with the following command: `cd app && npm run generate-locale -- <locale> ./main-process/i18n/`.
+
 ## License
 
 **Inky** and **ink** are released under the MIT license. Although we don't require attribution, we'd love to know if you decide to use **ink** a project! Let us know on [Twitter](http://www.twitter.com/inkleStudios) or [by email](mailto:info@inklestudios.com).

--- a/app/main-process/aboutWindow.js
+++ b/app/main-process/aboutWindow.js
@@ -4,13 +4,13 @@ const path = require("path");
 const ipc = electron.ipcMain;
 const fs = require("fs");
 const inkjsPackage = require('inkjs/package.json');
+const i18n = require('./i18n/i18n.js');
 
 
 const electronWindowOptions = {
     width: 340,
     height: 270,
     resizable: false,
-    title: "About Inky",
     show: false,
     autoHideMenuBar: true
 };
@@ -32,6 +32,8 @@ var aboutWindow = null;
 
 
 function AboutWindow(theme) {
+    electronWindowOptions.title = i18n._("About Inky");
+
     var w = new BrowserWindow(electronWindowOptions);
     w.loadURL("file://" + __dirname + "/../renderer/about/about.html");
 

--- a/app/main-process/aboutWindow.js
+++ b/app/main-process/aboutWindow.js
@@ -1,7 +1,6 @@
 const electron = require('electron');
 const BrowserWindow = electron.BrowserWindow;
 const path = require("path");
-const ipc = electron.ipcMain;
 const fs = require("fs");
 const inkjsPackage = require('inkjs/package.json');
 const i18n = require('./i18n/i18n.js');
@@ -12,7 +11,10 @@ const electronWindowOptions = {
     height: 270,
     resizable: false,
     show: false,
-    autoHideMenuBar: true
+    autoHideMenuBar: true,
+    webPreferences: {
+        preload: path.join(__dirname, '..', 'renderer', 'preload.js')
+    }
 };
 
 const versionFilePath = "ink/version.txt";
@@ -36,8 +38,6 @@ function AboutWindow(theme) {
 
     var w = new BrowserWindow(electronWindowOptions);
     w.loadURL("file://" + __dirname + "/../renderer/about/about.html");
-
-    // w.webContents.openDevTools();
 
     w.webContents.on("did-finish-load", () => {
         w.webContents.send("set-about-data", {

--- a/app/main-process/appmenus.js
+++ b/app/main-process/appmenus.js
@@ -6,6 +6,7 @@ const _ = require("lodash");
 const Menu = electron.Menu;
 const ProjectWindow = require("./projectWindow.js").ProjectWindow;
 const inkSnippets = require("./inkSnippets.js").snippets;
+const i18n = require('./i18n/i18n.js');
 
 function setupMenus(callbacks) {
     let themes = [];
@@ -44,315 +45,8 @@ function setupMenus(callbacks) {
         });
     }
 
-    const template = [
-        {
-            label: 'File',
-            submenu: [
-                {
-                    label: 'New Project',
-                    accelerator: 'CmdOrCtrl+N',
-                    click: callbacks.new
-                },
-                {
-                    label: 'New Included Ink File',
-                    accelerator: 'CmdOrCtrl+Alt+N',
-                    click: callbacks.newInclude
-                },
-                {
-                    type: 'separator'
-                },
-                {
-                    label: 'Open...',
-                    accelerator: 'CmdOrCtrl+O',
-                    click: callbacks.open
-                },
-                {
-                    label: 'Open Recent',
-                    submenu: computeRecent(ProjectWindow.getRecentFiles()),
-                    id: "recent"
-                },
-                {
-                    type: 'separator'
-                },
-                {
-                    label: 'Save Project',
-                    accelerator: 'CmdOrCtrl+S',
-                    enabled: callbacks.isFocusedWindow,
-                    click: callbacks.save
-                },
-                {
-                    type: 'separator'
-                },
-                {
-                    label: 'Export to JSON...',
-                    accelerator: 'CmdOrCtrl+Shift+S',
-                    enabled: callbacks.isFocusedWindow,
-                    click: callbacks.exportJson
-                },
-                {
-                    label: 'Export for web...',
-                    enabled: callbacks.isFocusedWindow,
-                    click: callbacks.exportForWeb
-                },
-                {
-                    label: 'Export story.js only...',
-                    accelerator: 'CmdOrCtrl+Alt+S',
-                    enabled: callbacks.isFocusedWindow,
-                    click: callbacks.exportJSOnly
-                },
-                {
-                    type: 'separator'
-                },
-                {
-                    label: 'Close',
-                    accelerator: 'CmdOrCtrl+W',
-                    role: 'close'
-                }
-            ]
-        },
-        {
-            label: 'Edit',
-            submenu: [
-                {
-                    label: 'Undo',
-                    accelerator: 'CmdOrCtrl+Z',
-                    role: 'undo'
-                },
-                {
-                    label: 'Redo',
-                    accelerator: 'Shift+CmdOrCtrl+Z',
-                    role: 'redo'
-                },
-                {
-                    type: 'separator'
-                },
-                {
-                    label: 'Cut',
-                    accelerator: 'CmdOrCtrl+X',
-                    role: 'cut'
-                },
-                {
-                    label: 'Copy',
-                    accelerator: 'CmdOrCtrl+C',
-                    role: 'copy'
-                },
-                {
-                    label: 'Paste',
-                    accelerator: 'CmdOrCtrl+V',
-                    role: 'paste'
-                },
-                {
-                    label: 'Select All',
-                    accelerator: 'CmdOrCtrl+A',
-                    role: 'selectall'
-                },
-                {
-                    type: 'separator'
-                },
-                {
-                    label: 'Useful Keyboard Shortcuts',
-                    enabled: callbacks.isFocusedWindow,
-                    click: callbacks.keyboardShortcuts
-                }
-            ]
-        },
-        {
-            label: "View",
-            submenu: [
-                {
-                    label: 'Toggle Full Screen',
-                    accelerator: process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
-                    click(item, focusedWindow) {
-                        if (focusedWindow)
-                            focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
-                    }
-                },
-                {
-                    label: 'Theme',
-                    submenu: themes
-                },
-                {
-                    label: "Zoom %",
-                    submenu: zoom_percents
-                },
-                {
-                    label: "Zoom (Increase) ",
-                    accelerator: 'CmdOrCtrl+=',
-                    click: callbacks.zoomIn
-                },
-                {
-                    label: "Zoom (Decrease) ",
-                    accelerator: 'CmdOrCtrl+-',
-                    click: callbacks.zoomOut
-                }
-            ]
-        },
-        {
-            label: 'Story',
-            submenu: [
-                {
-                    label: 'Go to anything...',
-                    accelerator: 'CmdOrCtrl+P',
-                    click: callbacks.gotoAnything
-                },
-                {
-                    label: 'Next Issue',
-                    accelerator: 'CmdOrCtrl+.',
-                    click: callbacks.nextIssue
-                },
-                {
-                    label: 'Add watch expression...',
-                    click: callbacks.addWatchExpression
-                },
-                {
-                    label: 'Tags visible',
-                    type: "checkbox",
-                    checked: true,
-                    click: callbacks.toggleTags
-                },
-                {
-                        label: 'Word count and more',
-                        enabled: callbacks.isFocusedWindow,
-                        click: callbacks.stats
-                }
-            ]
-        },
-        {
-            label: 'Ink',
-            submenu: [
-                // Filled in by the code at the bottom from the content in inkSnippets.js
-            ]
-        },
-        
-        {
-            label: 'Window',
-            role: 'window',
-            submenu: [
-                {
-                    label: 'Minimize',
-                    accelerator: 'CmdOrCtrl+M',
-                    role: 'minimize'
-                },
-                {
-                    label: 'Close',
-                    accelerator: 'CmdOrCtrl+W',
-                    role: 'close'
-                },
-                {
-                    label: 'Developer',
-                    submenu: [
-                        {
-                            label: 'Reload web view',
-                            accelerator: 'CmdOrCtrl+R',
-                            click(item, focusedWindow) {
-                                if (!focusedWindow) return;
-                                var clickedButtonIdx = dialog.showMessageBox(focusedWindow, {
-                                    type: 'question',
-                                    buttons: ['Yes', 'Cancel'],
-                                    title: 'Reload?',
-                                    message: 'Are you sure you want to reload the current window? Any unsaved changes will be lost.'
-                                });
-                                if( clickedButtonIdx == 0 ) {
-                                    focusedWindow.reload();
-                                }
-                            }
-                        },
-                        {
-                            label: 'Toggle Developer Tools',
-                            accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
-                            click(item, focusedWindow) {
-                                if (focusedWindow)
-                                    focusedWindow.webContents.toggleDevTools();
-                            }
-                        },
-                    ]
-                },
-            ]
-        },
-        {
-            label: 'Help',
-            role: 'help',
-            submenu: [
-                {
-                    label: 'Show Documentation',
-                    click: callbacks.showDocs
-                },
-            ]
-        },
-    ];
-
-    const name = app.getName();
-    const aboutWindowLabel = 'About ' + name;
-    // Mac specific menus
-    if (process.platform === 'darwin') {
-        template.unshift({
-            label: name,
-            submenu: [
-                {
-                    label: aboutWindowLabel,
-                    click: callbacks.showAbout
-                    // role: 'about'
-                },
-                {
-                    type: 'separator'
-                },
-                {
-                    label: 'Services',
-                    role: 'services',
-                    submenu: []
-                },
-                {
-                    type: 'separator'
-                },
-                {
-                    label: 'Hide ' + name,
-                    accelerator: 'Command+H',
-                    role: 'hide'
-                },
-                {
-                    label: 'Hide Others',
-                    accelerator: 'Command+Alt+H',
-                    role: 'hideothers'
-                },
-                {
-                    label: 'Show All',
-                    role: 'unhide'
-                },
-                {
-                    type: 'separator'
-                },
-                {
-                    label: 'Quit',
-                    accelerator: 'Command+Q',
-                    click() { app.quit(); }
-                },
-            ]
-        });
-
-        var windowMenu = _.find(template, menu => menu.role == "window");
-        windowMenu.submenu.push(
-            {
-                type: 'separator'
-            },
-            {
-                label: 'Bring All to Front',
-                role: 'front'
-            }
-        );
-    }
-    else
-    {
-        // Windows specific menu items
-        template.find(x => x.label === "Help").submenu.push(
-            {
-                label: aboutWindowLabel,
-                click: callbacks.showAbout
-            }
-        );
-    }
-
     // Generate menus for ink snippets
-    var inkSubMenu = _.find(template, menu => menu.label == "Ink").submenu;
+    const inkSubMenu = [];
     for(var category of inkSnippets) {
 
         // Category separator?
@@ -371,7 +65,7 @@ function setupMenus(callbacks) {
                 };
             } else {
                 return {
-                    label: snippet.name,
+                    label: i18n._(snippet.name),
                     click: (item, focussedWindow) => callbacks.insertSnippet(focussedWindow, snippet.ink)
                 }
             }
@@ -379,9 +73,314 @@ function setupMenus(callbacks) {
         });
         
         inkSubMenu.push({
-            label: category.categoryName,
+            label: i18n._(category.categoryName),
             submenu: items
         });
+    }
+
+    const template = [
+        {
+            label: i18n._('File'),
+            submenu: [
+                {
+                    label: i18n._('New Project'),
+                    accelerator: 'CmdOrCtrl+N',
+                    click: callbacks.new
+                },
+                {
+                    label: i18n._('New Included Ink File'),
+                    accelerator: 'CmdOrCtrl+Alt+N',
+                    click: callbacks.newInclude
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: i18n._('Open...'),
+                    accelerator: 'CmdOrCtrl+O',
+                    click: callbacks.open
+                },
+                {
+                    label: i18n._('Open Recent'),
+                    submenu: computeRecent(ProjectWindow.getRecentFiles()),
+                    id: "recent"
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: i18n._('Save Project'),
+                    accelerator: 'CmdOrCtrl+S',
+                    enabled: callbacks.isFocusedWindow,
+                    click: callbacks.save
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: i18n._('Export to JSON...'),
+                    accelerator: 'CmdOrCtrl+Shift+S',
+                    enabled: callbacks.isFocusedWindow,
+                    click: callbacks.exportJson
+                },
+                {
+                    label: i18n._('Export for web...'),
+                    enabled: callbacks.isFocusedWindow,
+                    click: callbacks.exportForWeb
+                },
+                {
+                    label: i18n._('Export story.js only...'),
+                    accelerator: 'CmdOrCtrl+Alt+S',
+                    enabled: callbacks.isFocusedWindow,
+                    click: callbacks.exportJSOnly
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: i18n._('Close'),
+                    accelerator: 'CmdOrCtrl+W',
+                    role: 'close'
+                }
+            ]
+        },
+        {
+            label: i18n._('Edit'),
+            submenu: [
+                {
+                    label: i18n._('Undo'),
+                    accelerator: 'CmdOrCtrl+Z',
+                    role: 'undo'
+                },
+                {
+                    label: i18n._('Redo'),
+                    accelerator: 'Shift+CmdOrCtrl+Z',
+                    role: 'redo'
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: i18n._('Cut'),
+                    accelerator: 'CmdOrCtrl+X',
+                    role: 'cut'
+                },
+                {
+                    label: i18n._('Copy'),
+                    accelerator: 'CmdOrCtrl+C',
+                    role: 'copy'
+                },
+                {
+                    label: i18n._('Paste'),
+                    accelerator: 'CmdOrCtrl+V',
+                    role: 'paste'
+                },
+                {
+                    label: i18n._('Select All'),
+                    accelerator: 'CmdOrCtrl+A',
+                    role: 'selectall'
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: i18n._('Useful Keyboard Shortcuts'),
+                    enabled: callbacks.isFocusedWindow,
+                    click: callbacks.keyboardShortcuts
+                }
+            ]
+        },
+        {
+            label: i18n._("View"),
+            submenu: [
+                {
+                    label: i18n._('Toggle Full Screen'),
+                    accelerator: process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
+                    click(item, focusedWindow) {
+                        if (focusedWindow)
+                            focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+                    }
+                },
+                {
+                    label: i18n._('Theme'),
+                    submenu: themes
+                },
+                {
+                    label: i18n._("Zoom %"),
+                    submenu: zoom_percents
+                },
+                {
+                    label: i18n._("Zoom (Increase) "),
+                    accelerator: 'CmdOrCtrl+=',
+                    click: callbacks.zoomIn
+                },
+                {
+                    label: i18n._("Zoom (Decrease) "),
+                    accelerator: 'CmdOrCtrl+-',
+                    click: callbacks.zoomOut
+                }
+            ]
+        },
+        {
+            label: i18n._('Story'),
+            submenu: [
+                {
+                    label: i18n._('Go to anything...'),
+                    accelerator: 'CmdOrCtrl+P',
+                    click: callbacks.gotoAnything
+                },
+                {
+                    label: i18n._('Next Issue'),
+                    accelerator: 'CmdOrCtrl+.',
+                    click: callbacks.nextIssue
+                },
+                {
+                    label: i18n._('Add watch expression...'),
+                    click: callbacks.addWatchExpression
+                },
+                {
+                    label: i18n._('Tags visible'),
+                    type: "checkbox",
+                    checked: true,
+                    click: callbacks.toggleTags
+                },
+                {
+                        label: i18n._('Word count and more'),
+                        enabled: callbacks.isFocusedWindow,
+                        click: callbacks.stats
+                }
+            ]
+        },
+        {
+            label: i18n._('Ink'),
+            submenu: inkSubMenu
+        },
+        
+        {
+            label: i18n._('Window'),
+            role: 'window',
+            submenu: [
+                {
+                    label: i18n._('Minimize'),
+                    accelerator: 'CmdOrCtrl+M',
+                    role: 'minimize'
+                },
+                {
+                    label: i18n._('Close'),
+                    accelerator: 'CmdOrCtrl+W',
+                    role: 'close'
+                },
+                {
+                    label: i18n._('Developer'),
+                    submenu: [
+                        {
+                            label: i18n._('Reload web view'),
+                            accelerator: 'CmdOrCtrl+R',
+                            click(item, focusedWindow) {
+                                if (!focusedWindow) return;
+                                var clickedButtonIdx = dialog.showMessageBox(focusedWindow, {
+                                    type: 'question',
+                                    buttons: [i18n._('Yes'), i18n._('Cancel')],
+                                    title: i18n._('Reload?'),
+                                    message: i18n._('Are you sure you want to reload the current window? Any unsaved changes will be lost.')
+                                });
+                                if( clickedButtonIdx == 0 ) {
+                                    focusedWindow.reload();
+                                }
+                            }
+                        },
+                        {
+                            label: i18n._('Toggle Developer Tools'),
+                            accelerator: process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+                            click(item, focusedWindow) {
+                                if (focusedWindow)
+                                    focusedWindow.webContents.toggleDevTools();
+                            }
+                        },
+                    ]
+                },
+            ]
+        },
+        {
+            label: i18n._('Help'),
+            role: 'help',
+            submenu: [
+                {
+                    label: i18n._('Show Documentation'),
+                    click: callbacks.showDocs
+                },
+            ]
+        },
+    ];
+
+    const name = app.getName();
+    const aboutWindowLabel = i18n._('About ') + name;
+    // Mac specific menus
+    if (process.platform === 'darwin') {
+        template.unshift({
+            label: name,
+            submenu: [
+                {
+                    label: aboutWindowLabel,
+                    click: callbacks.showAbout
+                    // role: 'about'
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: i18n._('Services'),
+                    role: 'services',
+                    submenu: []
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: i18n._('Hide ') + name,
+                    accelerator: 'Command+H',
+                    role: 'hide'
+                },
+                {
+                    label: i18n._('Hide Others'),
+                    accelerator: 'Command+Alt+H',
+                    role: 'hideothers'
+                },
+                {
+                    label: i18n._('Show All'),
+                    role: 'unhide'
+                },
+                {
+                    type: 'separator'
+                },
+                {
+                    label: i18n._('Quit'),
+                    accelerator: 'Command+Q',
+                    click() { app.quit(); }
+                },
+            ]
+        });
+
+        var windowMenu = _.find(template, menu => menu.role == "window");
+        windowMenu.submenu.push(
+            {
+                type: 'separator'
+            },
+            {
+                label: i18n._('Bring All to Front'),
+                role: 'front'
+            }
+        );
+    }
+    else
+    {
+        // Windows specific menu items
+        template.find(x => x.role === 'help').submenu.push(
+            {
+                label: aboutWindowLabel,
+                click: callbacks.showAbout
+            }
+        );
     }
 
     const menu = Menu.buildFromTemplate(template);
@@ -389,7 +388,7 @@ function setupMenus(callbacks) {
 
     ProjectWindow.setRecentFilesChanged(function(newRecentFiles) {
         _.find(
-            _.find(template, menu => menu.label == "File").submenu,
+            _.find(template, menu => menu.label == i18n._("File")).submenu,
             submenu => submenu.id == "recent"
         ).submenu = computeRecent(newRecentFiles);
         const menu = Menu.buildFromTemplate(template);

--- a/app/main-process/i18n/i18n.js
+++ b/app/main-process/i18n/i18n.js
@@ -1,0 +1,40 @@
+const electron = require('electron');
+const fs = require('fs');
+const path = require('path');
+
+class i18n {
+    constructor() {
+        this.currentLocale = null;
+        this.msgs = {}
+
+        electron.app.on('ready', () => {
+            this.switch(electron.app.getLocale());
+        });
+
+        electron.ipcMain.on('i18n._', (event, msgid) => {
+            event.returnValue = this._(msgid);
+        });
+    }
+
+    _(msgid) {
+        if (!(msgid in this.msgs) || !this.msgs[msgid].length) {
+            this.msgs[msgid] = msgid;
+        }
+        return this.msgs[msgid];
+    }
+
+    switch(lang) {
+        this.currentLocale = lang;
+        const file = path.join(__dirname, `${lang}.json`)
+        if (fs.existsSync(file)) {
+            this.msgs = require(file);
+        } else {
+            const defaultLocale = electron.app.getLocale();
+            if (lang != defaultLocale) {
+                this.switch(defaultLocale);
+            }
+        }
+    }
+}
+
+module.exports = new i18n();

--- a/app/main-process/projectWindow.js
+++ b/app/main-process/projectWindow.js
@@ -14,6 +14,9 @@ const electronWindowOptions = {
   minWidth: 350,
   minHeight: 250,
   titleBarStyle: 'hidden',
+  webPreferences: {
+      preload: path.join(__dirname, '..', 'renderer', 'preload.js')
+  }
 };
 
 var windows = [];

--- a/app/main-process/projectWindow.js
+++ b/app/main-process/projectWindow.js
@@ -6,6 +6,7 @@ const path = require("path");
 const fs = require("fs");
 const Inklecate = require("./inklecate.js").Inklecate;
 const Menu = electron.Menu;
+const i18n = require("./i18n/i18n.js");
 
 const electronWindowOptions = {
   width: 1300,
@@ -13,7 +14,6 @@ const electronWindowOptions = {
   minWidth: 350,
   minHeight: 250,
   titleBarStyle: 'hidden',
-  title: "Inky"
 };
 
 var windows = [];
@@ -31,6 +31,7 @@ function ProjectWindow(filePath) {
         e => e.checked
     ).label.toLowerCase();
 
+    electronWindowOptions.title = i18n._("Inky");
     this.browserWindow = new BrowserWindow(electronWindowOptions);
     this.browserWindow.loadURL("file://" + __dirname + "/../renderer/index.html");
     this.browserWindow.setSheetOffset(49);
@@ -170,10 +171,10 @@ function addRecentFile(filePath) {
 ProjectWindow.open = function(filePath) {
     if( !filePath ) {
         var multiSelectPaths = dialog.showOpenDialog({
-            title: "Open main ink file",
+            title: i18n._("Open main ink file"),
             properties: ['openFile'],
             filters: [
-                { name: 'Ink files', extensions: ['ink'] }
+                { name: i18n._('Ink files'), extensions: ['ink'] }
             ]
         });
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,6 +10,68 @@
       "integrity": "sha512-0a2X6cgN3RdPBL2MIlR6Lt0KlM7fOFsutuXcdglcOq6WvLnYXgPQSh0Mx6tO1KCAE8MxbHSOSTWDoUxRq+l3DA==",
       "dev": true
     },
+    "abab": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
+      "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
+      "dev": true
+    },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        }
+      }
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
+      }
+    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -303,6 +365,12 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -708,6 +776,29 @@
       "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=",
       "dev": true
     },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+          "dev": true
+        }
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -726,6 +817,17 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      }
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -739,6 +841,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decimal.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
       "dev": true
     },
     "decode-uri-component": {
@@ -760,6 +868,12 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "deepmerge": {
@@ -785,6 +899,23 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
+    },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "dev": true
+        }
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -882,6 +1013,46 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -938,6 +1109,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fd-slicer": {
@@ -1112,6 +1289,12 @@
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
     "har-validator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
@@ -1159,6 +1342,15 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1336,6 +1528,12 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+      "dev": true
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -1372,6 +1570,123 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
+    },
+    "jsdom": {
+      "version": "16.5.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.1.tgz",
+      "integrity": "sha512-pF73EOsJgwZekbDHEY5VO/yKXUkab/DuvrQB/ANVizbr6UAHJsDdHXuotZYwkJSGQl1JM+ivXaqY+XBDDL4TiA==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.5",
+        "acorn": "^8.0.5",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "is-potential-custom-element-name": "^1.0.0",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "request": "^2.88.2",
+        "request-promise-native": "^1.0.9",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0",
+        "ws": "^7.4.4",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "har-validator": {
+          "version": "5.1.5",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.12.3",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "tough-cookie": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+              "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+              "dev": true,
+              "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+              }
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+          "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.1.2"
+          },
+          "dependencies": {
+            "psl": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+              "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+              "dev": true
+            }
+          }
+        }
+      }
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1453,6 +1768,16 @@
         }
       }
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -1470,6 +1795,12 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -1685,6 +2016,12 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -1739,6 +2076,20 @@
         }
       }
     },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -1753,6 +2104,12 @@
       "requires": {
         "error-ex": "^1.2.0"
       }
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -1789,6 +2146,12 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -1814,6 +2177,12 @@
       "requires": {
         "pinkie": "^2.0.0"
       }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "1.0.4",
@@ -2012,6 +2381,34 @@
         }
       }
     },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        }
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -2069,6 +2466,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "semver": {
       "version": "5.5.0",
@@ -2196,6 +2602,12 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2274,6 +2686,12 @@
       "requires": {
         "has-flag": "^2.0.0"
       }
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
     },
     "tar-stream": {
       "version": "1.6.1",
@@ -2383,6 +2801,23 @@
         "punycode": "^1.4.1"
       }
     },
+    "tr46": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -2405,6 +2840,15 @@
       "dev": true,
       "optional": true
     },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
     "type-detect": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
@@ -2416,6 +2860,29 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
     },
     "urix": {
       "version": "0.1.0",
@@ -2474,6 +2941,24 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
     "wdio-dot-reporter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.10.tgz",
@@ -2520,10 +3005,59 @@
         }
       }
     },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true
+    },
     "wgxpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz",
       "integrity": "sha1-7vikudVYzEla06mit1FZfs2a9pA=",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.24",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
+      "integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^2.0.2",
+        "webidl-conversions": "^6.1.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
     "wordwrap": {
@@ -2536,6 +3070,24 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "ws": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
     "xtend": {

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "electron": "^4.2.0",
+    "jsdom": "^16.5.1",
     "markdown-html": "^0.0.8",
     "mocha": "^4.0.1",
     "spectron": "^3.8.0"

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "postinstall": "node ../build/createDocumentnavigation.js && markdown-html resources/Documentation/WritingWithInk.md -s resources/Documentation/documentation.css -o renderer/documentation/embedded.html",
     "start": "electron main-process/main.js",
-    "test": "./node_modules/mocha/bin/mocha"
+    "test": "./node_modules/mocha/bin/mocha",
+    "generate-locale": "node ../build/generateLocale.js"
   },
   "repository": {
     "type": "git",

--- a/app/renderer/about/about.html
+++ b/app/renderer/about/about.html
@@ -1,10 +1,6 @@
 <!DOCTYPE html>
 <html>
 
-<head>
-    <title>About Inky</title>
-</head>
-
 <style>
 body {
     text-align: center;

--- a/app/renderer/controller.js
+++ b/app/renderer/controller.js
@@ -25,6 +25,7 @@ const LiveCompiler = require("./liveCompiler.js").LiveCompiler;
 const InkProject = require("./inkProject.js").InkProject;
 const NavHistory = require("./navHistory.js").NavHistory;
 const GotoAnything = require("./goto.js").GotoAnything;
+const i18n = require("./i18n.js");
 
 InkProject.setEvents({
     "newProject": (project) => {
@@ -153,8 +154,8 @@ LiveCompiler.setEvents({
     },
     unexpectedError: (error) => {
         if( error.indexOf("Unhandled Exception") != -1 ) {
-            PlayerView.addTerminatingMessage("Sorry, the ink compiler crashed ☹", "error");
-            PlayerView.addTerminatingMessage("Here is some diagnostic information:", "error");
+            PlayerView.addTerminatingMessage(i18n._("Sorry, the ink compiler crashed ☹"), "error");
+            PlayerView.addTerminatingMessage(i18n._("Here is some diagnostic information:"), "error");
 
             // Make it a bit less verbose and concentrate on the useful stuff
             // [0x000ea] in /Users/blah/blah/blah/blah/ink/ParsedHierarchy/FlowBase.cs:377
@@ -164,7 +165,7 @@ LiveCompiler.setEvents({
 
             PlayerView.addLongMessage(error, "diagnostic");
         } else {
-            PlayerView.addTerminatingMessage("Ink compiler had an unexpected error ☹", "error");
+            PlayerView.addTerminatingMessage(i18n._("Ink compiler had an unexpected error ☹"), "error");
             PlayerView.addLongMessage(error, "error");
         }
     },
@@ -177,23 +178,23 @@ ipc.on("project-stats", (event, visible) => {
     LiveCompiler.getStats((statsObj) => {
         
         let messageLines = [];
-        messageLines.push("Project statistics:");
+        messageLines.push(i18n._("Project statistics:"));
         messageLines.push("");
         
-        messageLines.push("Words: "+statsObj["words"]);
+        messageLines.push(`${i18n._("Words")}: ${statsObj["words"]}`);
         messageLines.push("");
 
-        messageLines.push("Knots: "+statsObj["knots"]);
-        messageLines.push("Stitches: "+statsObj["stitches"]);
-        messageLines.push("Functions: "+statsObj["functions"]);
+        messageLines.push(`${i18n._("Knots")}: ${statsObj["knots"]}`);
+        messageLines.push(`${i18n._("Stitches")}: ${statsObj["stitches"]}`);
+        messageLines.push(`${i18n._("Functions")}: ${statsObj["functions"]}`);
         messageLines.push("");
 
-        messageLines.push("Choices: "+statsObj["choices"]);
-        messageLines.push("Gathers: "+statsObj["gathers"]);
-        messageLines.push("Diverts: "+statsObj["diverts"]);
+        messageLines.push(`${i18n._("Choices")}: ${statsObj["choices"]}`);
+        messageLines.push(`${i18n._("Gathers")}: ${statsObj["gathers"]}`);
+        messageLines.push(`${i18n._("Diverts")}: ${statsObj["diverts"]}`);
         messageLines.push("");
 
-        messageLines.push("Notes: Words should be accurate. Knots include functions. Gathers and diverts may include some implicitly added ones by the compiler, for example in weave. Diverts include END and DONE.");
+        messageLines.push(i18n._("Notes: Words should be accurate. Knots include functions. Gathers and diverts may include some implicitly added ones by the compiler, for example in weave. Diverts include END and DONE."));
 
         alert(messageLines.join("\n"));
     });
@@ -201,21 +202,21 @@ ipc.on("project-stats", (event, visible) => {
 
 ipc.on("keyboard-shortcuts", (event, visible) => {
     let messageLines = [];
-    messageLines.push("Useful Keyboard Shortcuts");
+    messageLines.push(i18n._("Useful Keyboard Shortcuts"));
     messageLines.push("");
-    messageLines.push("Find and Replace: Ctrl+H or Cmd+H");
+    messageLines.push(`${i18n._("Find and Replace")}: Ctrl+H ${i18n._("or")} Cmd+H`);
     messageLines.push("");
-    messageLines.push("Find: Ctrl+F or Cmd+F");
+    messageLines.push(`${i18n._("Find")}: Ctrl+F ${i18n._("or")} Cmd+F`);
     messageLines.push("");
-    messageLines.push("Go to Anything: Ctrl+P or Cmd+P");
+    messageLines.push(`${i18n._("Go to Anything")}: Ctrl+P ${i18n._("or")} Cmd+P`);
     messageLines.push("");
-    messageLines.push("Toggle Comment: Ctrl+/ or Cmd+/");
+    messageLines.push(`${i18n._("Toggle Comment")}: Ctrl+/ ${i18n._("or")} Cmd+/`);
     messageLines.push("");
-    messageLines.push("Add Multicursor Above: Ctrl+Alt+Up or Ctrl+Option+Up");
+    messageLines.push(`${i18n._("Add Multicursor Above")}: Ctrl+Alt+Up ${i18n._("or")} Ctrl+Option+Up`);
     messageLines.push("");
-    messageLines.push("Add Multicursor Below: Ctrl+Alt+Down or Ctrl+Option+Down");
+    messageLines.push(`${i18n._("Add Multicursor Below")}: Ctrl+Alt+Down ${i18n._("or")} Ctrl+Option+Down`);
     messageLines.push("");
-    messageLines.push("Temporarily Fold/Unfold Selection: Alt+L or Ctrl+Option+Down");
+    messageLines.push(`${i18n._("Temporarily Fold/Unfold Selection")}: Alt+L ${i18n._("or")} Ctrl+Option+Down`);
     messageLines.push("");
     alert(messageLines.join("\n"));
 });

--- a/app/renderer/expressionWatchView.js
+++ b/app/renderer/expressionWatchView.js
@@ -7,13 +7,15 @@ const EditSession = ace.require('ace/edit_session').EditSession;
 const Range = ace.require("ace/range").Range;
 const InkMode = require("./ace-ink-mode/ace-ink.js").InkMode;
 
+const i18n = require("./i18n.js");
+
 var expressionViews = [];
 var events = {};
 
 function ExpressionWatchView() {
     this.$expression = $(`
         <tr>
-            <td class="expressionLabel">Every turn:</td>
+            <td class="expressionLabel">${i18n._("Every turn:")}</td>
             <td class="expressionInput">
                 <div class="expressionEditor"></div>
                 <div class="removeButton"><span class="icon icon-cancel-circled"></span></div>

--- a/app/renderer/goto.js
+++ b/app/renderer/goto.js
@@ -9,6 +9,8 @@ const $ = window.jQuery = require('./jquery-2.2.3.min.js');
 const InkProject = require("./inkProject.js").InkProject;
 const EditorView = require("./editorView.js").EditorView;
 
+const i18n = require("./i18n.js");
+
 var $goto = null;
 var $gotoContainer = null;
 var $input = null;
@@ -271,12 +273,11 @@ function addResult(result, searchStr)
     }
 
     else if( type == "gotoLine" ) {
-        $result = $(`<li class='gotoLine'><p>➡︎ Go to line ${result.line+1}</p><p class='meta'>${result.lineContent}</p></li>`);
+        $result = $(`<li class='gotoLine'><p>➡︎ ${i18n._("Go to line")} ${result.line+1}</p><p class='meta'>${result.lineContent}</p></li>`);
     }
 
     else if( type == "runtimePath" ) {
-        $result = $(`<li class='runtimePath'><p>🔎 ${result.lineContent}</p><p class='meta'>${result.file.filename()} - line ${result.line+1} (looked up internal runtime path ${result.runtimePath})</p></li>`);
-        //$result = $(`<li class='runtimePath'><p>🔎 <strong>${result.file.relativePath()}, line ${result.line+1} (looked up internal path ${result.runtimePath})</p><p class='meta'>${result.lineContent}</p></li>`);
+        $result = $(`<li class='runtimePath'><p>🔎 ${result.lineContent}</p><p class='meta'>${result.file.filename()} - ${i18n._("line")} ${result.line+1} (${i18n._("looked up internal runtime path")} ${result.runtimePath})</p></li>`);
     }
 
     else if( type == "symbol" ) {
@@ -291,13 +292,13 @@ function addResult(result, searchStr)
 
         var filePath = result.inkFile.relativePath();
         var lineNo = result.row+1;
-        $result = $(`<li class='symbol'><p>✎ ${ancestorStr}${wrappedResult}</p><p class='meta'>${filePath} - line ${lineNo}</p></li>`);
+        $result = $(`<li class='symbol'><p>✎ ${ancestorStr}${wrappedResult}</p><p class='meta'>${filePath} - ${i18n._("line")} ${lineNo}</p></li>`);
     }
 
     else if( type == "content" ) {
         var filePath = result.file.relativePath();
         var lineNo = result.row+1;
-        $result = $(`<li class='content'><p>${wrappedResult}</p><p class='meta'>${filePath} - line ${lineNo}</p></li>`);
+        $result = $(`<li class='content'><p>${wrappedResult}</p><p class='meta'>${filePath} - ${i18n._("line")} ${lineNo}</p></li>`);
     }
 
     $result.data("result", result);

--- a/app/renderer/i18n.js
+++ b/app/renderer/i18n.js
@@ -1,0 +1,9 @@
+const { ipcRenderer } = require('electron');
+
+class i18n {
+    _(msgid) {
+        return ipcRenderer.sendSync('i18n._', msgid);
+    }
+}
+
+module.exports = new i18n();

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>Inky</title>
 
     <script>
       // Add the platform name as a class on the root HTML element for custom CSS

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -49,11 +49,11 @@
         <div class="buttons right">
           <div class="busySpinner"></div>
 
-          <div class="button step-back" title="Rewind a single choice">
+          <div class="button step-back i18n" title="Rewind a single choice">
             <span class="icon icon-reply"></span>
           </div>
 
-          <div class="button rewind" title="Restart story">
+          <div class="button rewind i18n" title="Restart story">
             <span class="icon icon-reply-all"></span>
           </div>
 
@@ -75,7 +75,7 @@
 
             <div class="nav-wrapper">
               <nav class="nav-group main-ink">
-                <h5 class="nav-group-title">Main ink file</h5>
+                <h5 class="nav-group-title i18n">Main ink file</h5>
                 <a class="nav-group-item active">
                   <span class="icon icon-book"></span>
                   <span class="filename"></span>
@@ -86,19 +86,19 @@
             <div class="footer">
               <a class="add-include-button">
                 <span class="icon icon-plus"></span>
-                Add new include
+                <span class="i18n">Add new include</span>
               </a>
               <div class="new-include-form">
-                <h5>Enter new ink file name:</h5>
+                <h5 class="i18n">Enter new ink file name:</h5>
                 <div class="inputWrapper">
-                  <input type="text" class="form-control" placeholder="Folder/inkFileName.ink">
+                  <input type="text" class="form-control i18n" placeholder="Folder/inkFileName.ink">
                 </div>
                 <div class="checkbox add-to-main-ink">
-                    <input type="checkbox" checked><span>Add to main ink</span>
+                    <input type="checkbox" checked><span class="i18n">Add to main ink</span>
                 </div>
                 <div class="form-buttons">
-                  <button id="add-include" class="btn btn-primary pull-right">Add</button>
-                  <button id="cancel-add-include" class="btn btn-default pull-right">Cancel</button>
+                  <button id="add-include" class="btn btn-primary pull-right i18n">Add</button>
+                  <button id="cancel-add-include" class="btn btn-default pull-right i18n">Cancel</button>
                 </div>
               </div>
             </div>
@@ -135,7 +135,7 @@
       </div><!-- photon window-content -->
       <div id="goto-anything-container" class="ignore-events">
         <div id="goto-anything" class="hidden">
-          <input placeholder="File name, stitch, knot, line number, or text"></input>
+          <input class="i18n" placeholder="File name, stitch, knot, line number, or text"></input>
           <ul class="results">
           </ul>
         </div>

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const _ = require("lodash");
 const chokidar = require('chokidar');
 const mkdirp = require('mkdirp');
+const i18n = require('./i18n.js');
 
 const EditorView = require("./editorView.js").EditorView;
 const NavView = require("./navView.js").NavView;
@@ -85,7 +86,7 @@ InkProject.prototype.addNewInclude = function(newIncludePath, addToMainInk) {
     // Make sure it doesn't already exist
     var alreadyExists = _.some(this.files, (f) => f.relativePath() == newIncludePath);
     if( alreadyExists ) {
-        alert("Could not create new include file at "+newIncludePath+" because it already exists!");
+        alert(`${i18n._("Could not create new include file at")} ${newIncludePath} ${i18n._("because it already exists!")}`);
         return null;
     }
 
@@ -146,7 +147,7 @@ InkProject.prototype.refreshIncludes = function() {
             // If it exists, and double check that it hasn't already been created during the async fs.stat
             if( stats.isFile() &&  !_.some(this.files, f => f.relativePath() == newIncludeRelPath) ) {
                 let newFile = this.createInkFile(newIncludeRelPath, isBrandNew = false, err => {
-                    alert("Failed to load ink file: "+err);
+                    alert(`${i18n._("Failed to load ink file:")} ${err}`);
                     this.files.remove(newFile);
                     this.refreshIncludes();
                 });
@@ -200,7 +201,7 @@ InkProject.prototype.startFileWatching = function() {
             console.log("Watch found new file - creating it: "+relPath);
 
             let newFile = this.createInkFile(newlyFoundAbsFilePath, isBrandNew = false, err => {
-                alert("Failed to load ink file: "+err);
+                alert(`${i18n._("Failed to load ink file:")} ${err}`);
                 this.files.remove(newFile);
                 this.refreshIncludes();
             });
@@ -321,7 +322,7 @@ function copyFile(source, destination, transform) {
 InkProject.prototype.export = function(exportType) {
 
     if( !this.ready ) {
-        alert("Project not quite fully loaded! Please try exporting again in a couple of seconds...");
+        alert(i18n._("Project not quite fully loaded! Please try exporting again in a couple of seconds..."));
         return;
     }
 
@@ -329,7 +330,7 @@ InkProject.prototype.export = function(exportType) {
     var inkJsCompatible = exportType == "js" || exportType == "web";
     LiveCompiler.exportJson(inkJsCompatible, (err, compiledJsonTempPath) => {
         if( err ) {
-            alert("Could not export: "+err);
+            alert(`${i18n._("Could not export:")} ${err}`);
             return;
         }
 
@@ -362,11 +363,11 @@ InkProject.prototype.export = function(exportType) {
 
         if( exportType == "json" ) {
             saveOptions.filters = [
-                { name: "JSON files", extensions: ["json"] }
+                { name: i18n._("JSON files"), extensions: ["json"] }
             ]
         } else if( exportType == "js" ) {
             saveOptions.filters = [
-                { name: "JavaScript files", extensions: ["js"] }
+                { name: i18n._("JavaScript files"), extensions: ["js"] }
             ]
         }
 
@@ -381,12 +382,12 @@ InkProject.prototype.export = function(exportType) {
                         // File already exists, or there's another error
                         // (error when code == ENOENT means file doens't exist, which is fine)
                         if( !err || err.code != "ENOENT" ) {
-                            if( err ) alert("Sorry, could not save to "+targetSavePath);
+                            if( err ) alert(`${i18n._("Sorry, could not save to")} ${targetSavePath}`);
 
                             if( stats.isFile() ) fs.unlinkSync(targetSavePath);
 
                             if( stats.isDirectory() ) {
-                                alert("Could not save because directory exists with the given name");
+                                alert(i18n._("Could not save because directory exists with the given name"));
                                 return
                             }
                         }
@@ -495,12 +496,12 @@ InkProject.prototype.tryClose = function() {
     if( this.hasUnsavedChanges ) {
         dialog.showMessageBox(remote.getCurrentWindow(), {
             type: "warning",
-            message: "Would you like to save changes before exiting?",
-            detail: "Your changes will be lost if you don't save.",
+            message: i18n._("Would you like to save changes before exiting?"),
+            detail: i18n._("Your changes will be lost if you don't save."),
             buttons: [
-                "Save",
-                "Don't save",
-                "Cancel"
+                i18n._("Save"),
+                i18n._("Don't save"),
+                i18n._("Cancel")
             ],
             defaultId: 0
         }, (response) => {

--- a/app/renderer/liveCompiler.js
+++ b/app/renderer/liveCompiler.js
@@ -1,6 +1,7 @@
 const ipc = require("electron").ipcRenderer;
 const _ = require("lodash");
-var randomstring = require("randomstring");
+const randomstring = require("randomstring");
+const i18n = require('./i18n.js');
 
 var namespace = null;
 var sessionIdx = 0;
@@ -325,7 +326,7 @@ ipc.on("play-exit-due-to-error", (event, exitCode, fromSessionId) => {
     if( !sessionIsCurrent(fromSessionId) ) return;
 
     if( fromSessionId == currentExportSessionId ) {
-        completeExport({message: "Ink has errors - please fix them before exporting."});
+        completeExport({message: i18n._("Ink has errors - please fix them before exporting.")});
     } else {
         if( replaying ) {
             replaying = false;
@@ -343,7 +344,7 @@ ipc.on("play-story-unexpected-error", (event, error, fromSessionId) => {
     if( !sessionIsCurrent(fromSessionId) ) return;
 
     if( fromSessionId == currentExportSessionId ) {
-        completeExport({message: "Unexpected error"});
+        completeExport({message: i18n._("Unexpected error")});
     } else {
         if( replaying ) {
             replaying = false;

--- a/app/renderer/navView.js
+++ b/app/renderer/navView.js
@@ -1,6 +1,7 @@
 const $ = window.jQuery = require('./jquery-2.2.3.min.js');
 const path = require("path");
 const _ = require("lodash");
+const i18n = require("./i18n.js");
 
 const slideAnimDuration = 200;
 var sidebarWidth = 200;
@@ -116,7 +117,7 @@ function setFiles(mainInk, allFiles) {
 
     if( unusedFiles.length > 0 )
         groupsArray.push({
-            name: "Unused files",
+            name: i18n._("Unused files"),
             files: unusedFiles
         });
 

--- a/app/renderer/playerView.js
+++ b/app/renderer/playerView.js
@@ -1,4 +1,5 @@
 const $ = window.jQuery = require('./jquery-2.2.3.min.js');
+const i18n = require('./i18n.js');
 
 var events = {};
 var lastFadeTime = 0;
@@ -230,7 +231,7 @@ function addHorizontalDivider()
 
 function addLineError(error, callback)
 {
-    var $aError = $("<a href='#'>Line "+error.lineNumber+": "+error.message+"</a>");
+    var $aError = $(`<a href='#'>${i18n._("Line")} ${error.lineNumber}: ${error.message}</a>`);
     $aError.on("click", callback);
 
     var $paragraph = $("<p class='error'></p>");

--- a/app/renderer/preload.js
+++ b/app/renderer/preload.js
@@ -1,0 +1,13 @@
+const i18n = require('./i18n.js');
+
+window.addEventListener('DOMContentLoaded', () => {
+    // auto-translate everything tagged with the i18n class
+    const mustBeTranslated = ['innerText', 'title', 'placeholder'];
+    document.querySelectorAll('.i18n').forEach(elem => {
+        mustBeTranslated.forEach(key => {
+            if (elem[key]) {
+                elem[key] = i18n._(elem[key]);
+            }
+        });
+    });
+});

--- a/app/renderer/toolbarView.js
+++ b/app/renderer/toolbarView.js
@@ -1,6 +1,7 @@
 const electron = require("electron");
 const remote = electron.remote;
 const $ = window.jQuery = require('./jquery-2.2.3.min.js');
+const i18n = require("./i18n.js");
 
 // Overriden by external setButtonActions call
 var events = {
@@ -74,7 +75,7 @@ function updateIssueSummary(issues, issueClickCallback) {
 
     if( errorCount == 0 && warningCount == 0 && todoCount == 0 ) {
         $summary.addClass("hidden");
-        $message.text("No issues.");
+        $message.text(i18n._("No issues."));
         $message.removeClass("hidden");
         $issues.addClass("hidden");
     } else {

--- a/build/generateLocale.js
+++ b/build/generateLocale.js
@@ -1,0 +1,97 @@
+(() => {
+    const fs = require('fs');
+    const path = require('path');
+    const readline = require('readline');
+
+    // JSON utils
+    const PrettyJSON = (str) => JSON.stringify(str, null, 2); 
+
+    // FS utils
+    const WriteJSONTo = (json, filePath) => {
+        if (filePath) {
+            fs.writeFileSync(filePath, PrettyJSON(json));
+            console.info("All done.");
+        } else {
+            console.info("No output directory specified, the file content will be printed on stdout.\n");
+            console.info(outputFile);
+            console.info(PrettyJSON(json));
+        }
+    };
+    const OverWriteJSONTo = (json, filePath) => {
+        fs.rmSync(filePath);
+        WriteJSONTo(json, filePath);
+    };
+
+    // Extract all msgids from a directory
+    const re = new RegExp(/i18n\._\((['"])(.+?)\1\)/, 'gm');
+    const Extract = dirPath => {
+        let msgs = {};
+
+        fs.readdirSync(dirPath).forEach(file => {
+            // we don't want anything to do with node_modules/ or acesrc/
+            if (['node_modules', 'acesrc'].indexOf(file) >= 0) { return; }
+
+            const filePath = path.join(dirPath, file);
+            if (fs.lstatSync(filePath).isDirectory()) {
+                msgs = Object.assign({}, msgs, Extract(filePath));
+            } else if (path.extname(file) === ".js") {
+                const fileContent = fs.readFileSync(filePath);
+                const matches = Array.from(RegExp.prototype[Symbol.matchAll].call(re, fileContent));
+                matches.forEach(match => msgs[match[2]] = "");
+            }
+        });
+
+        return msgs;
+    };
+
+    // Handle CLI arguments
+    const IsNodeInvoke = () => !process.argv[0].endsWith(__filename);
+    const CheckArgs = () => process.argv.length >= (IsNodeInvoke() ? 3 : 2);
+    const GetLocale = () => IsNodeInvoke() ? process.argv[2] : process.argv[1];
+    const HasOutputDir = () => process.argv.length >= (IsNodeInvoke() ? 4 : 5);
+    const GetOutputDir = () => process.argv[IsNodeInvoke() ? 3 : 2];
+
+    if (!fs.existsSync(path.join(process.cwd(), 'package.json'))) {
+        console.error("ERROR: This script should be executed from the app root directory.");
+        process.exit(1);
+    }
+
+    if (!CheckArgs()) {
+        console.error("ERROR: Please specify a locale to generate.");
+        process.exit(1);
+    }
+
+    const localeName = GetLocale();
+    const outputDir = HasOutputDir() ? path.join(process.cwd(), GetOutputDir()) : null;
+    const outputFile = `${localeName}.json`;
+    
+    // Extract everything
+    const msgs = Extract(process.cwd());
+
+    if (!outputDir) {
+        WriteJSONTo(msgs, null);
+    } else {
+        const outputPath = path.join(outputDir, outputFile);
+        console.info(`Generated locale will be writen to ${outputPath}`);
+        if (fs.existsSync(outputPath)) {
+            const rl = readline.createInterface(process.stdin, process.stdout);
+            console.info("File already exists.")
+            rl.question("Merge? y/[n]\n", function(answer) {
+                if (answer.toLowerCase() === "y") {
+                    const current = JSON.parse(fs.readFileSync(outputPath));
+                    OverWriteJSONTo(Object.assign({}, msgs, current), outputPath);
+                    rl.close();
+                } else {
+                    rl.question("Overwrite? y/[n]\n", function(answer) {
+                        if (answer.toLowerCase() === "y") {
+                            OverWriteJSONTo(msgs, outputPath);
+                        }
+                        rl.close();
+                    });
+                }
+            })
+        } else {
+            WriteJSONTo(msgs, outputPath);
+        }
+    }
+})();


### PR DESCRIPTION
Hey 🙂 
This is a pretty naive approach to translation, but it was quick to implement and should be sturdy enough to be built upon in the future.

Long story short:
 * Whenever you have a constant string that should be translated in your Javascript code, call `i18n._("toBeTranslated")` on it. This works both in the main process and the renderer.
 * Whenever you have a constant string that should be translated in your HTML markup, add the `i18n` class to the surrounding element. This currently works for text content, and attributes (only `title` and `placeholder` for now but anyone can easily add other attributes to the list).
 * There's a new npm script to generate `.json` files containing all the keys defined in the codebase¹.
 * Documentation windows aren't supported for now. I think it'd probably deserve a bit of thinking about how it's going to be actually translated.
 * For now, the application is loading the language returned by `electron.app.getLocale()` when it starts and there's no button to switch languages.

Bests.

---

1. `npm run generate-locale -- locale-to-generate [path-to-i18n-folder]`