### PR TITLE
Dark mode fixes, new colorsafe and focus themes

### DIFF
--- a/app/main-process/appmenus.js
+++ b/app/main-process/appmenus.js
@@ -10,7 +10,7 @@ const inkSnippets = require("./inkSnippets.js").snippets;
 function setupMenus(callbacks) {
     let themes = [];
     const defaultTheme = 'light';
-    for (const theme of ['light', 'dark']) {
+    for (const theme of ['light', 'dark', 'contrast', 'focus']) {
         themes.push({
             label: theme.substring(0, 1).toUpperCase() + theme.substring(1),
             type: 'radio',

--- a/app/renderer/about/controller.js
+++ b/app/renderer/about/controller.js
@@ -10,10 +10,14 @@ ipc.on("set-about-data", (event, data) => {
 });
 
 function updateTheme(event, newTheme) {
-		if (newTheme && newTheme.toLowerCase() === 'dark') {
-        $("body").addClass("dark");
-    } else {
-        $("body").removeClass("dark");
+    let themes = ["dark", "contrast", "focus"];
+    themes = themes.filter(e => e !== newTheme);
+    if (newTheme && newTheme.toLowerCase() !== 'main')
+    {
+        $(".body").addClass(newTheme);
+    }
+    for (const theme of themes) {
+        $(".body").removeClass(theme);
     }
 }
 

--- a/app/renderer/contrast.css
+++ b/app/renderer/contrast.css
@@ -1,0 +1,153 @@
+.window.contrast #main,
+.window.contrast #editor,
+.window.contrast #toolbar {
+    background-color: #282828;
+}
+
+.window.contrast #main .sidebar,
+.window.contrast #main .sidebar .footer {
+    background-color: #282828;
+}
+
+.window.contrast h1.title {
+    color: white;
+}
+
+
+.window.contrast #main .sidebar .filename,
+.window.contrast #main .sidebar .footer .add-include-button,
+.window.contrast #main .sidebar .footer .new-include-form h5 {
+    color: #888;
+}
+
+.window.contrast #main .sidebar .nav-group-item.active {
+    background: #666;
+}
+
+.window.contrast #main .sidebar .nav-group-item.active .filename {
+    color: #CCC;
+}
+
+.window.contrast #toolbar .button:hover .icon {
+    color: #CCC;
+}
+
+/* e.g. filename input */
+.window.contrast #main .sidebar .footer input {
+    background: #333;
+    border: 1px solid #888;
+    color: #888;
+}
+
+.window.contrast #main .sidebar .footer .checkbox {
+    color: #888;
+}
+
+
+
+.window.contrast #toolbar {
+    border-bottom: 1px solid #888;
+}
+
+.window.contrast #toolbar div.issuesSummary .issueCount {
+    color: #888;
+}
+
+.window.contrast #main .sidebar .footer {
+    border-top: 1px solid #555;
+}
+
+
+.window.contrast .ace_editor .ace_marker-layer .ace_selection {
+    background-color: #444;
+}
+
+.window.contrast .ace_editor .ace_marker-layer .ace_selected-word {
+    background-color: #999;
+    border-color: #dedede;
+}
+
+.window.contrast #editor,
+.window.contrast #player,
+.window.contrast .ace_editor .ace_cursor {
+    /*color: #f0f0f0; */
+    color: #faf2e7;
+}
+
+.window.contrast .ace_editor .ace_indent-guide {
+    opacity: .1;
+}
+
+.window.contrast .ace_editor .ace_marker-layer .ace_active-line {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.window.contrast #player hr {
+    border-top-color: #444;
+}
+
+.window.contrast #player p.choice a:hover {
+    color: #999;
+}
+
+.window.contrast #editor .ace_gutter-layer,
+.window.contrast .split {
+    background: #444;
+}
+
+.window.contrast #editor .ace-error {
+    background: #81265b;
+}
+
+.window.contrast #editor .ace_todo,
+.window.contrast #editor .ace-todo {
+    background: #a97410;
+    color: #000000;
+}
+
+.window.contrast #editor .ace_warning,
+.window.contrast #editor .ace-warning {
+    background: #0f3553;
+}
+
+.window.contrast .ace_editor span.ace_flow.ace_declaration,
+.window.contrast .ace_editor span.ace_divert,
+.window.contrast .ace_editor span.ace_choice.ace_label,
+.window.contrast .ace_editor span.ace_gather.ace_label,
+.window.contrast .ace_editor span.ace_glue,
+.window.contrast .ace_editor span.ace_include,
+.window.contrast .ace_editor span.ace_external {
+    color:#3eebff;
+}
+
+.window.contrast .ace_editor span.ace_choice.ace_bullets,
+.window.contrast .ace_editor span.ace_choice.ace_weaveBracket,
+.window.contrast .ace_editor span.ace_gather.ace_bullets {
+    color: #00b6a5;
+}
+
+.window.contrast .ace_editor span.ace_var-decl,
+.window.contrast .ace_editor span.ace_list-decl {
+    color: #00b6a5;
+}
+.window.contrast .ace_editor span.ace_logic:not(.ace_innerContent) {
+    color: #00b6a5;
+}
+
+.window.contrast #main.hideTags .ace_editor span.ace_tag {
+    color: #282828;
+}
+
+.window.contrast ::-webkit-scrollbar {
+    width: .75rem;
+    background: #282828;
+    border-left: 1px solid #323232;
+}
+
+.window.contrast ::-webkit-scrollbar-thumb {
+    background: #323232;
+}
+
+.window.contrast .sidebar .nav-wrapper::-webkit-scrollbar-thumb {
+    background: #323232;
+}

--- a/app/renderer/controller.js
+++ b/app/renderer/controller.js
@@ -309,11 +309,15 @@ ipc.on("set-tags-visible", (event, visible) => {
 
 
 function updateTheme(event, newTheme) {
-	if (newTheme && newTheme.toLowerCase() === 'dark') {
-		$(".window").addClass("dark");
-	} else {
-		$(".window").removeClass("dark");
-	}
+    let themes = ["dark", "contrast", "focus"];
+    themes = themes.filter(e => e !== newTheme);
+    if (newTheme && newTheme.toLowerCase() !== 'main')
+    {
+        $(".window").addClass(newTheme);
+    }
+    for (const theme of themes) {
+        $(".window").removeClass(theme);
+    }
 	LiveCompiler.setEdited();
 }
 

--- a/app/renderer/dark.css
+++ b/app/renderer/dark.css
@@ -96,13 +96,18 @@
 }
 
 .window.dark #editor .ace-error {
-    background: darkred;
+    background: #580000
 }
 
 .window.dark #editor .ace_todo,
 .window.dark #editor .ace-todo {
-    background:#f2ad2b;
-    color: #784a0f;
+    background: #a97410;
+    color: #000000;
+}
+
+.window.dark #editor .ace_warning,
+.window.dark #editor .ace-warning {
+    background: #0f3553;
 }
 
 .window.dark .ace_editor span.ace_flow.ace_declaration,

--- a/app/renderer/focus.css
+++ b/app/renderer/focus.css
@@ -1,0 +1,153 @@
+.window.focus #main,
+.window.focus #editor,
+.window.focus #toolbar {
+    background-color: #282828;
+}
+
+.window.focus #main .sidebar,
+.window.focus #main .sidebar .footer {
+    background-color: #282828;
+}
+
+.window.focus h1.title {
+    color: white;
+}
+
+
+.window.focus #main .sidebar .filename,
+.window.focus #main .sidebar .footer .add-include-button,
+.window.focus #main .sidebar .footer .new-include-form h5 {
+    color: #888;
+}
+
+.window.focus #main .sidebar .nav-group-item.active {
+    background: #666;
+}
+
+.window.focus #main .sidebar .nav-group-item.active .filename {
+    color: #CCC;
+}
+
+.window.focus #toolbar .button:hover .icon {
+    color: #CCC;
+}
+
+/* e.g. filename input */
+.window.focus #main .sidebar .footer input {
+    background: #333;
+    border: 1px solid #888;
+    color: #888;
+}
+
+.window.focus #main .sidebar .footer .checkbox {
+    color: #888;
+}
+
+
+
+.window.focus #toolbar {
+    border-bottom: 1px solid #888;
+}
+
+.window.focus #toolbar div.issuesSummary .issueCount {
+    color: #888;
+}
+
+.window.focus #main .sidebar .footer {
+    border-top: 1px solid #555;
+}
+
+
+.window.focus .ace_editor .ace_marker-layer .ace_selection {
+    background-color: #444;
+}
+
+.window.focus .ace_editor .ace_marker-layer .ace_selected-word {
+    background-color: #999;
+    border-color: #dedede;
+}
+
+.window.focus #editor,
+.window.focus #player,
+.window.focus .ace_editor .ace_cursor {
+    /*color: #f0f0f0; */
+    color: #faf1c6;
+}
+
+.window.focus .ace_editor .ace_indent-guide {
+    opacity: .1;
+}
+
+.window.focus .ace_editor .ace_marker-layer .ace_active-line {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.window.focus #player hr {
+    border-top-color: #444;
+}
+
+.window.focus #player p.choice a:hover {
+    color: #999;
+}
+
+.window.focus #editor .ace_gutter-layer,
+.window.focus .split {
+    background: #444;
+}
+
+.window.focus #editor .ace-error {
+    background: #580000
+}
+
+.window.focus #editor .ace_todo,
+.window.focus #editor .ace-todo {
+    background: #5f6238;
+    color:  #444;
+}
+
+.window.focus #editor .ace_warning,
+.window.focus #editor .ace-warning {
+    background: #0f3553;
+}
+
+.window.focus .ace_editor span.ace_flow.ace_declaration,
+.window.focus .ace_editor span.ace_divert,
+.window.focus .ace_editor span.ace_choice.ace_label,
+.window.focus .ace_editor span.ace_gather.ace_label,
+.window.focus .ace_editor span.ace_glue,
+.window.focus .ace_editor span.ace_include,
+.window.focus .ace_editor span.ace_external {
+    color: #434f53;
+}
+
+.window.focus .ace_editor span.ace_choice.ace_bullets,
+.window.focus .ace_editor span.ace_choice.ace_weaveBracket,
+.window.focus .ace_editor span.ace_gather.ace_bullets {
+    color:  #535353;
+}
+
+.window.focus .ace_editor span.ace_var-decl,
+.window.focus .ace_editor span.ace_list-decl {
+    color: #535353;
+}
+.window.focus .ace_editor span.ace_logic:not(.ace_innerContent) {
+    color: #535353;
+}
+
+.window.focus #main.hideTags .ace_editor span.ace_tag {
+    color: #535353;
+}
+
+.window.focus ::-webkit-scrollbar {
+    width: .75rem;
+    background: #282828;
+    border-left: 1px solid #323232;
+  }
+  
+.window.focus ::-webkit-scrollbar-thumb {
+    background: #323232;
+}
+
+.window.focus .sidebar .nav-wrapper::-webkit-scrollbar-thumb {
+    background: #323232;
+}

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -16,6 +16,8 @@
     <link rel="stylesheet" href="main.css">
     <link rel="stylesheet" href="inkTheme.css">
     <link rel="stylesheet" href="dark.css">
+    <link rel="stylesheet" href="contrast.css">
+    <link rel="stylesheet" href="focus.css">
 
     <div class="window">
       


### PR DESCRIPTION
In this PR we:
- Fixed some dark mode highlighting issues that were making it hard on the eye.
- Added new colorsafe/contrast and focus themes, for users with colorblindness and writers who want to focus on writing.
- Made small alterations to the theme-switching logic to make adding new themes easier. 

There were some complaints about the bright yellow highlight for loose end errors in dark mode.

![image](https://user-images.githubusercontent.com/3412295/111892328-61c01000-89f2-11eb-99b8-5869176d3c7d.png)
(Above: Notable users raise issues with the bright yellow error highlights.

This has been replaced with a less glaring blue. The red has also been darkened for the dark mode error messages.

![image](https://user-images.githubusercontent.com/3412295/111892355-a8156f00-89f2-11eb-9853-ffcad46f57d3.png)
 (Above: New darker error message colors for dark mode.)

A contrast mode has also been added - it is intended to be colorsafe and usable for most variants of weak and strong colorblindness. It has been tested with someone with red-weak/protanomaly, and tested against most common types of colorblindness in a simulator.

![image](https://user-images.githubusercontent.com/3412295/111892577-a187f700-89f4-11eb-960e-928b9359b9bb.png)
(Above: Respectively, left to right - contrast mode in full color, contrast mode under red-weak/protanomaly filter, contrast mode under red-strong/protanopia)

Finally, a focus theme has been added - it's an implementation of mrcsbmr's concentration mode that they once showed off in the Discord. It subdues everything except the story text (and errors), hiding logic and syntax, which should hopefully be useful for anybody wanting to focus on reading the story text and nothing else.

![image](https://user-images.githubusercontent.com/3412295/111892606-e14ede80-89f4-11eb-9b9c-4b9b930828a2.png)

(Above: Focus theme seen with The Intercept.)

![image](https://user-images.githubusercontent.com/3412295/111892487-d3e52480-89f3-11eb-8cc2-640933c77f9f.png)
(Above: Selecting the new modes)