### PR TITLE
[Bugfix] Large number of errors correctly displayed

### DIFF
--- a/app/main-process/inklecate.js
+++ b/app/main-process/inklecate.js
@@ -147,13 +147,22 @@ function compile(compileInstruction, requester) {
     var issueRegex = /^(ERROR|WARNING|RUNTIME ERROR|RUNTIME WARNING|TODO): ('([^']+)' )?line (\d+): (.*)/;
     var debugSourceRegex = /^DebugSource: (line (\d+) of (.*)|Unknown source)/;
 
+    var stdoutTextBuffer = "";
     playProcess.stdout.on('data', (text) => {
 
         // Strip Byte order mark
         text = text.replace(/^\uFEFF/, '');
         if( text.length == 0 ) return;
 
-        var lines = text.split('\n');
+        stdoutTextBuffer += text;
+        // end of transmission should always be a \n or }
+        // if not, wait for more data.
+        if(!["\n", "}"].includes(stdoutTextBuffer.substr(-1))){
+            return;
+        }
+
+        var lines = stdoutTextBuffer.split('\n');
+        stdoutTextBuffer = ""; //we have enough : clear the buffer.
 
         for(var i=0; i<lines.length; ++i) {
             var line = lines[i].trim();


### PR DESCRIPTION
### Bug
Inky just stopped displaying errors (_No issues._) if number of error was too important.

Before
![image](https://user-images.githubusercontent.com/1090485/117811321-b2205500-b260-11eb-9d99-cadf4ec4e51a.png)


### Why
This was caused by inky trying to parse truncated output from inklecate.

### Solution
Buffer and wait for EOL or } (end of Json) before processing inklecate's output

After
![image](https://user-images.githubusercontent.com/1090485/117811333-b64c7280-b260-11eb-898c-2037b3c6696f.png)



