### PR TITLE
Fixed ace highlight rules for choices, gathers, block comments

### DIFF
--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -52,7 +52,7 @@ var inkHighlightRules = function() {
             ]
         }],
         "#choice": [{
-            regex: /(\s*)((?:[\*\+]\s?)+)(\s*)(?:(\(\s*)(\w+)(\s*\)))?/,
+            regex: /^(\s*)((?:[\*\+]\s?)+)(\s*)(?:(\(\s*)(\w+)(\s*\)))?/,
             token: [
                 "choice",                           // whitespace
                 "choice.bullets",                   // * or +
@@ -80,7 +80,13 @@ var inkHighlightRules = function() {
                     defaultToken: "choice.weaveInsideBrackets" 
                 }]
             }, {
+                include: "#choice"
+            }, {
+                include: "#gather"
+            }, {
                 include: "#mixedContent"
+            }, {
+                include: "#comments"
             }, {
                 defaultToken: "choice"
             }]
@@ -212,6 +218,8 @@ var inkHighlightRules = function() {
                 next: "pop"
             }, {
                 include: "#escapes"
+            }, {
+                include: "#gather"
             }, {
                 include: "#comments"
             }, {


### PR DESCRIPTION
I've noticed a few issues with Inky's highlighting rules, illustrated in the following passage.

```* A * /* * C *// A/*
*/

A * A * /* * C *// A/*
*/

* choice #tag
* choice 2 #tag
-
-
-
```

You can see a before and after of the changes here.

<img width="406" alt="Screen Shot 2021-05-31 at 2 45 08 pm" src="https://user-images.githubusercontent.com/37443796/120151749-38f09e00-c21f-11eb-8efc-299a62b147f5.png">
