### PR TITLE
Tentative fix for scroll issues in the web player

### DIFF
--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -174,6 +174,8 @@
                 // Don't follow <a> link
                 event.preventDefault();
 
+                storyContainer.style.height = contentBottomEdgeY()+"px";
+
                 // Remove all existing choices
                 removeAll(".choice");
 
@@ -191,7 +193,7 @@
         // Extend height to fit
         // We do this manually so that removing elements and creating new ones doesn't
         // cause the height (and therefore scroll) to jump backwards temporarily.
-        storyContainer.style.height = contentBottomEdgeY()+"px";
+        storyContainer.style.height = "auto";
 
         if( !firstTime )
             scrollDown(previousBottomEdge);


### PR DESCRIPTION
See [#674](https://github.com/inkle/ink/issues/674). When playing a story in the web player, images are added to the div with a height of zero, which is updated after they load in. If they're loaded after the inner div's height is locked, the player won't be able to scroll down, potentially causing a soft lock. This fix locks the story's height after a choice is chosen, and unlocks it right before scrolling down. I'm not sure if it's a perfect solution, but it should prevent both soft locks and the jump upwards described in main.js circa line 193.