### PR TITLE
Create unique temp directories and clean up afterwards

### DIFF
--- a/app/main-process/inklecate.js
+++ b/app/main-process/inklecate.js
@@ -25,19 +25,36 @@ catch(e) {
 }
 
 var tempInkPath;
-const tmpDir = os.tmpdir();
-fs.mkdtemp(`${tmpDir}${path.sep}inky_compile_`, (err, folder) => {
-    if (err) {
-        throw new Error(err);
-    }
 
-    tempInkPath = folder;
-})
+function setUp() {
+    const tmpDir = os.tmpdir();
+    fs.mkdtemp(`${tmpDir}${path.sep}inky_compile_`, (err, folder) => {
+        if (err) {
+            throw new Error(err);
+        }
+
+        tempInkPath = folder;
+    })
+}
+
+function tearDown() {
+    if (tempInkPath) {
+        try {
+            // only available from node version 14.14
+            fs.rmSync(tempInkPath, {recursive: true, force: true});
+        } catch (err) {
+            console.error(`Failed to delete temporary directory ${tempInkPath}: ${err}`);
+        }
+    }
+}
 
 var sessions = {};
 
 
 function compile(compileInstruction, requester) {
+    if (!tempInkPath) {
+        throw new Error("Temporary directory not initialized");
+    }
 
     var sessionId = compileInstruction.sessionId;
 
@@ -358,5 +375,7 @@ ipc.on("get-runtime-path-in-source", (event, runtimePath, sessionId) => {
 
 
 exports.Inklecate = {
-    killSessions: killSessions
+    setUp,
+    tearDown,
+    killSessions
 }

--- a/app/main-process/inklecate.js
+++ b/app/main-process/inklecate.js
@@ -1,6 +1,7 @@
 const child_process = require('child_process');
 const spawn = child_process.spawn;
 const fs = require('fs');
+const os = require('os');
 const path = require("path");
 const electron = require('electron');
 const ipc = electron.ipcMain;
@@ -24,11 +25,14 @@ catch(e) {
 }
 
 var tempInkPath;
-if (process.platform == "darwin" || process.platform == "linux") {
-    tempInkPath = process.env.TMPDIR ? path.join(process.env.TMPDIR, "inky_compile") : "/tmp/inky_compile";
-} else {
-    tempInkPath = path.join(process.env.temp, "inky_compile")
-}
+const tmpDir = os.tmpdir();
+fs.mkdtemp(`${tmpDir}${path.sep}inky_compile_`, (err, folder) => {
+    if (err) {
+        throw new Error(err);
+    }
+
+    tempInkPath = folder;
+})
 
 var sessions = {};
 

--- a/app/main-process/main.js
+++ b/app/main-process/main.js
@@ -36,6 +36,8 @@ app.on('before-quit', function () {
     // We need this to differentiate between pressing quit (which should quit) or closing all windows
     // (which leaves the app open)
     isQuitting = true;
+
+    Inklecate.tearDown();
 });
 
 ipc.on("project-cancelled-close", (event) => {
@@ -46,6 +48,8 @@ ipc.on("project-cancelled-close", (event) => {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', function () {
+
+    Inklecate.setUp();
 
     app.on('window-all-closed', function () {
         if (process.platform != 'darwin' || isQuitting) {


### PR DESCRIPTION
Use `os.tmpdir` and `fs.mkdtemp` to create a uniquely named temporary directory in the correct place.

Also attempt to remove the temporary directory on application exit. This uses `fs.rmSync` which is only available in Node 14, which might be too new.