### PR TITLE
Fix broken documentation anchor links

### DIFF
--- a/build/createDocumentnavigation.js
+++ b/build/createDocumentnavigation.js
@@ -15,7 +15,7 @@ const mkdirp = require('../app/node_modules/mkdirp');
 //    It can happen that multiple '-' are directly following each other. In this case the last three entrys
 //    replaced these with one '-'.
 
-var characters = ['#x', '?x-', '>x', '<x', ')x-', '(x-', ':x', ' x-', '.x', '/x-', "'x-", '`x-', '--x-', '--x-', '--x-', '--x-', '--x-', '--x-', '"x'];
+var characters = ['#x', '?x-', '>x', '<x', ')x-', '(x-', ':x', ' x-', '.x', '/x-', "'x-", '`x', '"x', ',x', '!x-', '--x-', '--x-', '--x-', '--x-', '--x-', '--x-'];
 
 function initializeNavigation() {
     fs.readFile('../app/resources/Documentation/documentationWindowPrefab.html', 'utf8', function (firstErr, html) {


### PR DESCRIPTION
I added checks for commas and exclamation marks (these links are currently failing - e.g., "Health warning!" and "Sequences, cycles and other alternatives") and changed the current backtick behavior to accurately reflect how the character is altered by the markdown-html module (this was causing "Using `-> DONE `" to fail). I moved the punctuation checks before the dash checks in case removing a piece of punctuation creates a double dash. 