### PR TITLE
Upgrade inkjs version

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "chokidar": "^3.3.1",
         "fuzzaldrin-plus": "^0.5",
-        "inkjs": "^2.0.0",
+        "inkjs": "^2.1.0",
         "lodash": "^4.17.15",
         "mkdirp": "^0.5.1",
         "randomstring": "^1.1.5"
@@ -1527,9 +1527,9 @@
       "dev": true
     },
     "node_modules/inkjs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/inkjs/-/inkjs-2.0.0.tgz",
-      "integrity": "sha512-rYKIPfY0GygxabFl04fFqQa8iisN1KY+4j+SOxLYVbirIzLL/t1BmO6Z7DuW8/PnRYRzsWu/wnjL+ZpJ0BxyAg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/inkjs/-/inkjs-2.1.0.tgz",
+      "integrity": "sha512-M4b2mHZYWxlcft9zaGbGh0t4Bi3M8no/O86N8uwLA6UzP8M1pNGmcyqyfxUmNqyDTQ4/caMx2EqwvNTv/N10SQ=="
     },
     "node_modules/inquirer": {
       "version": "3.3.0",
@@ -4654,9 +4654,9 @@
       "dev": true
     },
     "inkjs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/inkjs/-/inkjs-2.0.0.tgz",
-      "integrity": "sha512-rYKIPfY0GygxabFl04fFqQa8iisN1KY+4j+SOxLYVbirIzLL/t1BmO6Z7DuW8/PnRYRzsWu/wnjL+ZpJ0BxyAg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/inkjs/-/inkjs-2.1.0.tgz",
+      "integrity": "sha512-M4b2mHZYWxlcft9zaGbGh0t4Bi3M8no/O86N8uwLA6UzP8M1pNGmcyqyfxUmNqyDTQ4/caMx2EqwvNTv/N10SQ=="
     },
     "inquirer": {
       "version": "3.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "chokidar": "^3.3.1",
     "fuzzaldrin-plus": "^0.5",
-    "inkjs": "^2.0.0",
+    "inkjs": "^2.1.0",
     "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
     "randomstring": "^1.1.5"


### PR DESCRIPTION
Insure latest version of inkjs (2.1.0) is used in web export.
Includes : 
- Fixed PRNG for shuffle of size 7
- Bugfixes on save/load

Only the runtime is exported in the webexport, not the compiler.