### PR TITLE
Disable web animations when the user prefers reduced motion

### DIFF
--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -215,15 +215,29 @@
     // Various Helper functions
     // -----------------------------------
 
+    // Detects whether the user accepts animations
+    function isAnimationEnabled() {
+        return window.matchMedia('(prefers-reduced-motion: no-preference)').matches;
+    }
+
     // Fades in an element after a specified delay
     function showAfter(delay, el) {
-        el.classList.add("hide");
-        setTimeout(function() { el.classList.remove("hide") }, delay);
+        if( isAnimationEnabled() ) {
+            el.classList.add("hide");
+            setTimeout(function() { el.classList.remove("hide") }, delay);
+        } else {
+            // If the user doesn't want animations, show immediately
+            el.classList.remove("hide");
+        }
     }
 
     // Scrolls the page down, but no further than the bottom edge of what you could
     // see previously, so it doesn't go too far.
     function scrollDown(previousBottomEdge) {
+        // If the user doesn't want animations, let them scroll manually
+        if ( !isAnimationEnabled() ) {
+            return;
+        }
 
         // Line up top of screen with the bottom of where the previous content ended
         var target = previousBottomEdge;

--- a/app/export-for-web-template/style.css
+++ b/app/export-for-web-template/style.css
@@ -7,8 +7,10 @@ body {
     overflow: hidden;
 }
 
-body.switched {
-    transition: color 0.6s, background-color 0.6s;
+@media screen and (prefers-reduced-motion: no-preference) {
+    body.switched {
+        transition: color 0.6s, background-color 0.6s;
+    }
 }
 
 h1,
@@ -55,12 +57,17 @@ h2 {
     display: block;
     width: 100%;
     background: white;
-    transition: color 0.6s, background 0.6s;
     margin: 0;
     padding-top: 6px;
     padding-bottom: 6px;
     height: 14px;
     top: 0;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+    .written-in-ink {
+        transition: color 0.6s, background 0.6s;
+    }
 }
 
 /* 
@@ -100,8 +107,10 @@ h2 {
     background: white;
 }
 
-.switched .container {
-    transition: background-color 0.6s;
+@media screen and (prefers-reduced-motion: no-preference) {
+    .switched .container {
+        transition: background-color 0.6s;
+    }
 }
 
 p {
@@ -115,13 +124,21 @@ a {
     font-weight: 700;
     color: #b97c2c;
     font-family: sans-serif;
-    transition: color 0.6s;
     text-decoration: none;
 }
 
 a:hover {
     color: black;
-    transition: color 0.1s;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+    a {
+        transition: color 0.6s;
+    }
+
+    a:hover {
+        transition: color 0.1s;
+    }
 }
 
 strong {
@@ -145,7 +162,12 @@ img {
 
 .container>* {
     opacity: 1.0;
-    transition: opacity 1.0s;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+    .container>* {
+        transition: opacity 1.0s;
+    }
 }
 
 /*
@@ -193,7 +215,12 @@ img {
     top: 4px;
     user-select: none;
     background: white;
-    transition: color 0.6s, background 0.6s;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+    #controls {
+        transition: color 0.6s, background 0.6s;
+    }
 }
 
 #controls [disabled] {
@@ -238,11 +265,16 @@ body.dark {
 
 .dark a {
     color: #cc8f1a;
-    transition: color 0.6s;
 }
 
 .dark a:hover {
     color: white;
+}
+
+@media screen and (prefers-reduced-motion: no-preference) {
+    .dark a {
+        transition: color 0.6s;
+    }
 }
 
 .dark strong {


### PR DESCRIPTION
The [`prefers-reduced-motion` media query](https://css-tricks.com/introduction-reduced-motion-media-query/) allows users to specify an accessibility setting for less animation.

The purpose of this PR is to respect this setting in web export.

- Scrolling: Smooth scrolling triggers seasickness, so disable it. Instant scrolling is usually preferred but would be disorienting in the context of Ink games. Instead, let the user scroll at their own pace.
- Fade-in: A row of flashing paragraphs can also be a vestibular trigger. Show all the paragraphs at once.
- Colour transitions: Not necessary for seasickness reduction, but exposes current app state more clearly.

See also: [PR for inkjs](https://github.com/y-lohse/inkjs/pull/966) with similar changes.