### PR TITLE
allow to assign shortcuts for the custom submenus

### DIFF
--- a/app/main-process/appmenus.js
+++ b/app/main-process/appmenus.js
@@ -123,6 +123,10 @@ function refresh() {
                     if( menuItem.ink ) {
                         templateMenuItem.click = (item, focussedWindow) => callbacks.insertSnippet(focussedWindow, menuItem.ink)
                         valid = true;
+                        if (menuItem.accelerator)
+                            templateMenuItem.accelerator = menuItem.accelerator;
+                        else if (menuItem.shortcut)
+                            templateMenuItem.accelerator = menuItem.shortcut;
                     }
 
                     else if( menuItem.submenu && Array.isArray(menuItem.submenu) ) {


### PR DESCRIPTION
as described. 
Allow to assign short-cuts for custom ink submenus (with the notation per Electron Accelerators https://www.electronjs.org/docs/latest/api/accelerator)

        "customInkSnippets": [
            {
                "name": "Heaven's Vault",
                "submenu": [
                    {
                        "name": "Camera",
                        "ink": ">>> CAMERA: Wide shot"
                        "shortcut: "Alt+1"
                    },
