### PR TITLE
Resolved issue with certain diacritics

### DIFF
--- a/app/renderer/main.css
+++ b/app/renderer/main.css
@@ -593,8 +593,8 @@ img.issue-icon.warning {
   right: 0;
   left: 50%;
 
-  font-family: Verdana, Geneva, sans-serif;
-  font-weight: lighter;
+  font-family: system-ui, -apple-system, Geneva, sans-serif;
+  font-weight: 400;
   color: #555;
 }
 


### PR DESCRIPTION
Removed Verdana font so previewer uses the system font first, which has support for all diacritics as far as I've been able to tell between iOS and Windows.

See this thread for additional details: https://github.com/inkle/inky/issues/444