### PR TITLE
Updated continueStory to fix issue with image tags and scrolling

### DIFF
--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -174,6 +174,11 @@
                 // Don't follow <a> link
                 event.preventDefault();
 
+				// Extend height to fit
+				// We do this manually so that removing elements and creating new ones doesn't
+				// cause the height (and therefore scroll) to jump backwards temporarily.
+				storyContainer.style.height = contentBottomEdgeY()+"px";
+
                 // Remove all existing choices
                 removeAll(".choice");
 
@@ -188,10 +193,8 @@
             });
         });
 
-        // Extend height to fit
-        // We do this manually so that removing elements and creating new ones doesn't
-        // cause the height (and therefore scroll) to jump backwards temporarily.
-        storyContainer.style.height = contentBottomEdgeY()+"px";
+		// Unset storyContainer's height, allowing it to resize itself
+		storyContainer.style.height = "";
 
         if( !firstTime )
             scrollDown(previousBottomEdge);


### PR DESCRIPTION
To address a recurring issue caused by image tags (discussed in ink's issue [#674](https://github.com/inkle/ink/issues/674)) — where images loading into the `storyContainer` div could cause choices to be pushed down below its maximum height, often blocking progress — I've changed `continueStory()` to only briefly lock `storyContainer`'s height while removing choices, instead permanently locking it to the latest value of `contentBottomEdgeY()`.

I've noticed a similar issue with `scrollDown()`, which can't calculate the right targe until the images have loaded in. Unfortunately, this commit does nothing to address that, but it should still help prevent users from having their stories break when they use an image tag.