### PR TITLE
Web player tag capitalisation fix

### DIFF
--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -174,6 +174,11 @@
                 // Don't follow <a> link
                 event.preventDefault();
 
+				// Extend height to fit
+				// We do this manually so that removing elements and creating new ones doesn't
+				// cause the height (and therefore scroll) to jump backwards temporarily.
+				storyContainer.style.height = contentBottomEdgeY()+"px";
+
                 // Remove all existing choices
                 removeAll(".choice");
 
@@ -188,10 +193,8 @@
             });
         });
 
-        // Extend height to fit
-        // We do this manually so that removing elements and creating new ones doesn't
-        // cause the height (and therefore scroll) to jump backwards temporarily.
-        storyContainer.style.height = contentBottomEdgeY()+"px";
+		// Unset storyContainer's height, allowing it to resize itself
+		storyContainer.style.height = "";
 
         if( !firstTime )
             scrollDown(previousBottomEdge);

--- a/app/export-for-web-template/main.js
+++ b/app/export-for-web-template/main.js
@@ -70,6 +70,7 @@
                 // Detect tags of the form "X: Y". Currently used for IMAGE and CLASS but could be
                 // customised to be used for other things too.
                 var splitTag = splitPropertyTag(tag);
+				splitTag.property = splitTag.property.toUpperCase();
 
                 // AUDIO: src
                 if( splitTag && splitTag.property == "AUDIO" ) {


### PR DESCRIPTION
I've seen a few people now get confused by the undocumented requirement for tags to be capitalised in order to work with the web player. This tweak automatically capitalises tags before comparison, so `#clear` will function identically to `#CLEAR`.