### PR TITLE
Fix bug when save file is cancelled, null path is passed around

### DIFF
--- a/app/main-process/projectWindow.js
+++ b/app/main-process/projectWindow.js
@@ -158,6 +158,7 @@ ProjectWindow.prototype.zoom = function(amount) {
 
 // Try to load up an optional <ink_root_file_name>.settings.json file
 ProjectWindow.prototype.refreshProjectSettings = function(rootInkFilePath) {
+    if (!rootInkFilePath) return
     
     let self = this;
 
@@ -279,6 +280,7 @@ ProjectWindow.clearRecentFiles = function() {
 }
 
 function addRecentFile(filePath) {
+    if (!filePath) return;
     const resolvedFilePath = path.resolve(filePath);
     const recentFiles = ProjectWindow.getRecentFiles();
     const newRecentFiles = recentFiles.indexOf(resolvedFilePath) >= 0 ?


### PR DESCRIPTION
A bug was occurring when one pressed save, and cancelled the save multiple times. I have added guards to related functions to reject null paths early.
This is the error that is fixed:
![image](https://github.com/user-attachments/assets/c391d2e4-d3b7-4f7c-b158-ed2304f00949)
