### PR TITLE
Fixed Windows path inclusion errors by using `path.normalize()` instead of `path.format(path.parse())`

### DIFF
--- a/app/renderer/inkFile.js
+++ b/app/renderer/inkFile.js
@@ -25,6 +25,12 @@ function InkFile(anyPath, mainInkFile, isBrandNew, inkMode, events) {
     // Default filename if creating a new file, and passed null to constructor
     anyPath = anyPath || "Untitled.ink";
 
+    // Convert anyPath to a normalized path string
+    if (typeof anyPath === "object") {
+        anyPath = path.parse(anyPath);
+    }
+    anyPath = path.normalize(anyPath);
+
     this.mainInkFile = mainInkFile;
 
     // Obtain relative path by looking at main ink file
@@ -274,7 +280,7 @@ InkFile.prototype.addIncludeLine = function(relativePath) {
 
     // Normally we allow the InkFileSymbols class to do this,
     // but by the time it gets round to doing parsing, it'll be too late.
-    this.includes.push(relativePath);
+    this.includes.push(path.normalize(relativePath));
     this.events.includesChanged();
 
     // Insert the include text itself

--- a/app/renderer/inkFileSymbols.js
+++ b/app/renderer/inkFileSymbols.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const path = require("path");
 const TokenIterator = ace.require("ace/token_iterator").TokenIterator;
 const _ = require("lodash");
 
@@ -154,7 +155,8 @@ InkFileSymbols.prototype.parse = function() {
 
         // INCLUDE
         else if( tok.type.indexOf("include.filepath") != -1 && tok.value.trim().length > 0 ) {
-            includes.push(tok.value);
+            // Normalize path when adding include
+            includes.push(path.normalize(tok.value));
             lastIncludeRow = it.getCurrentTokenRow();
         }
 

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -124,7 +124,7 @@ InkProject.prototype.refreshIncludes = function() {
             // fix include relative path on windows
             // on windows path should be either always stored using the same folder separator (\\ or /).
             // mixing them can create unexpected behaviours.
-            incPath = path.format(path.parse(incPath));
+            incPath = path.normalize(incPath);
 
             let alreadyDone = relPathsFromINCLUDEs.contains(incPath);
 

--- a/app/renderer/inkProject.js
+++ b/app/renderer/inkProject.js
@@ -101,7 +101,7 @@ InkProject.prototype.addNewInclude = function(newIncludePath, addToMainInk) {
     var newIncludeFile = this.createInkFile(newIncludePath || null, isBrandNew = true);
 
     if( addToMainInk )
-        this.mainInk.addIncludeLine(newIncludeFile.relativePath());
+        this.mainInk.addIncludeLine(newIncludePath);
 
     NavView.setFiles(this.mainInk, this.files);
     EditorView.setFiles(this.files);
@@ -120,12 +120,6 @@ InkProject.prototype.refreshIncludes = function() {
             return;
 
         inkFile.includes.forEach(incPath => {
-            
-            // fix include relative path on windows
-            // on windows path should be either always stored using the same folder separator (\\ or /).
-            // mixing them can create unexpected behaviours.
-            incPath = path.normalize(incPath);
-
             let alreadyDone = relPathsFromINCLUDEs.contains(incPath);
 
             relPathsFromINCLUDEs.push(incPath);


### PR DESCRIPTION
Fixes #551

`path.format(path.parse())` seems to only fix Windows paths up to one layer deep. `path.normalize()` solves this issue on Windows.

This is untested on other platforms! Please check this doesn't break file creation on a POSIX system before merging.